### PR TITLE
v1.0.7: bump mysql-replication to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.0.6',
+      version='1.0.7',
       description='Singer.io tap for extracting data from MySQL - PipelineWise compatible',
       author='Stitch',
       url='https://github.com/transferwise/pipelinewise-tap-mysql',
@@ -18,7 +18,7 @@ setup(name='pipelinewise-tap-mysql',
           'singer-python==5.3.1',
           'PyMySQL==0.7.11',
           'backoff==1.3.2',
-          'mysql-replication==0.18',
+          'mysql-replication==0.21',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
`BinLogStreamReader` class in `pymysqlreplication` misreads `datetime(3)` columns. e.g
the value `2019-12-05 15:05:18.517` is converted into python's `datetime.datetime(2019, 12, 5, 15, 5, 18, 517)`, then when we want to get the isoformat of this datetime object, we get `2019-12-05T15:05:18.000517` .

This happens during binlog replication only. I tried the latest version of `pymysqlreplication` and the bug was gone.