### PR TITLE
[AP-483] Update bookmark only before writing state message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.1.2',
+      version='1.1.3',
       description='Singer.io tap for extracting data from MySQL - PipelineWise compatible',
       author='Stitch',
       url='https://github.com/transferwise/pipelinewise-tap-mysql',

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -378,11 +378,6 @@ def _run_binlog_sync(mysql_conn, reader, binlog_streams_map, state):
                                 binlog_event.schema,
                                 binlog_event.table)
 
-        state = update_bookmarks(state,
-                                 binlog_streams_map,
-                                 reader.log_file,
-                                 reader.log_pos)
-
         # The iterator across python-mysql-replication's fetchone method should ultimately terminate
         # upon receiving an EOF packet. There seem to be some cases when a MySQL server will not send
         # one causing binlog replication to hang.
@@ -391,6 +386,10 @@ def _run_binlog_sync(mysql_conn, reader, binlog_streams_map, state):
 
         if ((rows_saved and rows_saved % UPDATE_BOOKMARK_PERIOD == 0) or
                 (events_skipped and events_skipped % UPDATE_BOOKMARK_PERIOD == 0)):
+            state = update_bookmarks(state,
+                                     binlog_streams_map,
+                                     reader.log_file,
+                                     reader.log_pos)
             singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 


### PR DESCRIPTION
## Description

@ivan-transferwise made same great work and measured the current performance of tap-mysql and [target-snowflake](https://github.com/transferwise/pipelinewise-target-snowflake) and realised that tap-mysql currently sends data slower than target-snowflake can process it. That means if we want to reduce replication lag from mysql to snowflake we need to improve this tap first.

After some further cProfile-ing using a database where this tap currently processes ~1600 events/seconds from the binlog, we found that the most of the time spent on [update_bookmark](https://github.com/transferwise/pipelinewise-tap-mysql/blob/07fa7d7b6e67f7b256f8c9c241b9571993d6d55c/tap_mysql/sync_strategies/binlog.py#L223) and [singer.write_boookmark](https://github.com/transferwise/pipelinewise-tap-mysql/blob/07fa7d7b6e67f7b256f8c9c241b9571993d6d55c/tap_mysql/sync_strategies/binlog.py#L225) functions which called after every single binlog event that we read.

For example if we process 1 million binlog events from a busy mysql server, we call `update_bookmark` 1 millions of time and `singer.write_boookmark` 2 millions of time.

This PR calls the `update_bookmarks` functions only when it's required, at the time we write the state message to STDOUT. Using this change the performance improved from **1600 events/sec to 4500 events/sec**
