### PR TITLE
[AP-483] Update bookmark when reading bookmark finished

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.1.3',
+      version='1.1.4',
       description='Singer.io tap for extracting data from MySQL - PipelineWise compatible',
       author='Stitch',
       url='https://github.com/transferwise/pipelinewise-tap-mysql',


### PR DESCRIPTION
This PR is to update bookmark one more time right after when every event processed from the binlog. This is required to send binlog positions at the very end of the process that is out of the `UPDATE_BOOKMARK_PERIOD`. 