### PR TITLE
[AP-483] Update bookmark only if binlog position is valid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.1.4',
+      version='1.1.5',
       description='Singer.io tap for extracting data from MySQL - PipelineWise compatible',
       author='Stitch',
       url='https://github.com/transferwise/pipelinewise-tap-mysql',

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -400,10 +400,11 @@ def _run_binlog_sync(mysql_conn, reader, binlog_streams_map, state):
             singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
     # Update singer bookmark at the last time to point it the the last processed binlog event
-    state = update_bookmarks(state,
-                             binlog_streams_map,
-                             log_file,
-                             log_pos)
+    if log_file and log_pos:
+        state = update_bookmarks(state,
+                                 binlog_streams_map,
+                                 log_file,
+                                 log_pos)
 
 
 def sync_binlog_stream(mysql_conn, config, binlog_streams, state):


### PR DESCRIPTION
This PR is to update bookmark only if the `log_file` and `log_pos` is not Null.