### PR TITLE
Json support

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -86,6 +86,9 @@ def schema_for_column(column):
     elif data_type in FLOAT_TYPES:
         result.type = ['null', 'number']
 
+    elif data_type == 'json':
+        result.type = ['null', 'string']
+
     elif data_type == 'decimal':
         result.type = ['null', 'number']
         result.multipleOf = 10 ** (0 - column.numeric_scale)

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -87,7 +87,7 @@ def schema_for_column(column):
         result.type = ['null', 'number']
 
     elif data_type == 'json':
-        result.type = ['null', 'string']
+        result.type = ['null', 'object']
 
     elif data_type == 'decimal':
         result.type = ['null', 'number']

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -861,6 +861,38 @@ class TestEscaping(unittest.TestCase):
         self.assertEqual(record_message.record, {'b c': 1})
 
 
+class TestJsonTables(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = test_utils.get_test_connection()
+
+        with connect_with_backoff(self.conn) as open_conn:
+            with open_conn.cursor() as cursor:
+                cursor.execute('CREATE TABLE json_table (val json)')
+                cursor.execute('INSERT INTO json_table (val) VALUES ( \'{"a": 10, "b": "c"}\')')
+
+        self.catalog = test_utils.discover_catalog(self.conn, {})
+        for stream in self.catalog.streams:
+            stream.key_properties = []
+
+            stream.metadata = [
+                {'breadcrumb': (), 'metadata': {'selected': True, 'database-name': 'tap_mysql_test'}},
+                {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
+            ]
+
+            stream.stream = stream.table
+            test_utils.set_replication_method_and_key(stream, 'FULL_TABLE', None)
+
+    def runTest(self):
+        global SINGER_MESSAGES
+        SINGER_MESSAGES.clear()
+        tap_mysql.do_sync(self.conn, {}, self.catalog, {})
+
+        record_message = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))[0]
+        self.assertTrue(isinstance(record_message, singer.RecordMessage))
+        self.assertEqual(record_message.record, {'val': '{"a": 10, "b": "c"}'})
+
+
 class TestSupportedPK(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Based on upstream code: https://github.com/singer-io/tap-mysql/pull/111 and https://github.com/singer-io/tap-mysql/pull/120

I changed the "string" to "object" type (as peter mentioned in slack) instead, so it is recognized in the targets as jsonb automatically. The fastsync seems to work without any changes (mysql -> postgres in my case)