### PR TITLE
v1.3.1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -------------------
 
 -  Fix dependency issue by removing `attrs` from `setup.py`
--  Bump `pymsql` to `0.9.3`
+-  Bump `pymysql` to `0.9.3`
 
 1.3.0 (2020-05-18)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.3.1 (2020-06-15)
+-------------------
+
+-  Fix dependency issue by removing `attrs` from `setup.py`
+-  Bump `pymsql` to `0.9.3`
+
 1.3.0 (2020-05-18)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.3.0',
+      version='1.3.1',
       description='Singer.io tap for extracting data from MySQL - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
New release candidate to PyPI: 1.3.1
Changelog:

1.3.1 (2020-06-15)
-------------------

-  Fix dependency issue by removing `attrs` from `setup.py`
-  Bump `pymysql` to `0.9.3`