### PR TITLE
Revert to pymysql 0.7.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='pipelinewise-tap-mysql',
       install_requires=[
           'pendulum==1.2.0',
           'pipelinewise-singer-python==1.*',
-          'PyMySQL==0.9.3',
+          'PyMySQL==0.7.11',
           'mysql-replication==0.21',
           'pyyaml==5.3',
       ],


### PR DESCRIPTION
PyMSQL `0.9.3` has some not backward compatible changes in handling invalid datetime columns. Some changes introduced in `0.8.1` that breaks the current expected behaviour of the driver.

The expected old behaviour is detailed and used in this PR: https://github.com/transferwise/pipelinewise/pull/444


If 2 rows were inserted where date_col is `2017-02-31 00:00:00` and  `2000-00-00 17:18:40` then running `select concat(date_col, ''), date_col from table` should return:

```
concat(date_col, '') |   date_col
------------------------------------------------------------
2017-02-31 00:00:00  |  2017-03-03 00:00:00
2000-00-00 17:18:40  |  1999-11-30 17:18:40 
```

This behaviour changed in pymysql `0.8.1`, but the current implementation requires it. This PR revers pymysql to the old pymsql.

We can consider to upgrade to a most recent pymysql only if we change the implementation of how we're dealing with invalid mysql dates in the PR above in the main PPW fastsync method. 