### PR TITLE
v1.3.2 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.3.2 (2020-06-15)
+-------------------
+
+-  Revert `pymysql` back to `0.7.11`.
+   `pymysql >= 0.8.1` introducing some not expected and not backward compatible changes how it's dealing with
+   invalid datetime columns.
+
 1.3.1 (2020-06-15)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.3.1',
+      version='1.3.2',
       description='Singer.io tap for extracting data from MySQL - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
New release candidate to PyPI: 1.3.2
Changelog:

1.3.2 (2020-06-15)
-------------------

-  Revert `pymysql` back to `0.7.11`.
   `pymysql >= 0.8.1` introducing some not expected and not backward compatible changes how it's dealing with invalid datetime columns.