### PR TITLE
[AP-742] Detect new/renamed columns from binlog message and update schema

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python3
 # pylint: disable=missing-docstring,too-many-locals
-
-import collections
-import itertools
 import copy
-import pendulum
 import pymysql
 import singer
 import singer.metrics as metrics
 
-from singer import metadata, Schema, get_logger
-from singer.catalog import Catalog, CatalogEntry
+from singer import metadata, get_logger
+from singer.catalog import Catalog
 
 import tap_mysql.sync_strategies.binlog as binlog
 import tap_mysql.sync_strategies.common as common
@@ -18,19 +14,10 @@ import tap_mysql.sync_strategies.full_table as full_table
 import tap_mysql.sync_strategies.incremental as incremental
 
 from tap_mysql.connection import connect_with_backoff, MySQLConnection
+from tap_mysql.discover_utils import discover_catalog, resolve_catalog
+from tap_mysql.stream_utils import write_schema_message
 
 LOGGER = get_logger('tap_mysql')
-
-Column = collections.namedtuple('Column', [
-    "table_schema",
-    "table_name",
-    "column_name",
-    "data_type",
-    "character_maximum_length",
-    "numeric_precision",
-    "numeric_scale",
-    "column_type",
-    "column_key"])
 
 REQUIRED_CONFIG_KEYS = [
     'host',
@@ -39,257 +26,9 @@ REQUIRED_CONFIG_KEYS = [
     'password'
 ]
 
-pymysql.converters.conversions[pendulum.Pendulum] = pymysql.converters.escape_datetime
-
-STRING_TYPES = {'char', 'enum', 'longtext', 'mediumtext', 'text', 'varchar'}
-
-BYTES_FOR_INTEGER_TYPE = {
-    'tinyint': 1,
-    'smallint': 2,
-    'mediumint': 3,
-    'int': 4,
-    'bigint': 8
-}
-
-FLOAT_TYPES = {'float', 'double'}
-
-DATETIME_TYPES = {'datetime', 'timestamp', 'date', 'time'}
-
-BINARY_TYPES = {'binary', 'varbinary'}
-
-
-def schema_for_column(column):
-    """Returns the Schema object for the given Column."""
-    data_type = column.data_type.lower()
-    column_type = column.column_type.lower()
-
-    inclusion = 'available'
-    # We want to automatically include all primary key columns
-    if column.column_key.lower() == 'pri':
-        inclusion = 'automatic'
-
-    result = Schema(inclusion=inclusion)
-
-    if data_type == 'bit' or column_type.startswith('tinyint(1)'):
-        result.type = ['null', 'boolean']
-
-    elif data_type in BYTES_FOR_INTEGER_TYPE:
-        result.type = ['null', 'integer']
-        bits = BYTES_FOR_INTEGER_TYPE[data_type] * 8
-        if 'unsigned' in column.column_type:
-            result.minimum = 0
-            result.maximum = 2 ** bits - 1
-        else:
-            result.minimum = 0 - 2 ** (bits - 1)
-            result.maximum = 2 ** (bits - 1) - 1
-
-    elif data_type in FLOAT_TYPES:
-        result.type = ['null', 'number']
-
-    elif data_type == 'json':
-        result.type = ['null', 'object']
-
-    elif data_type == 'decimal':
-        result.type = ['null', 'number']
-        result.multipleOf = 10 ** (0 - column.numeric_scale)
-        return result
-
-    elif data_type in STRING_TYPES:
-        result.type = ['null', 'string']
-        result.maxLength = column.character_maximum_length
-
-    elif data_type in DATETIME_TYPES:
-        result.type = ['null', 'string']
-        result.format = 'date-time'
-
-    elif data_type in BINARY_TYPES:
-        result.type = ['null', 'string']
-        result.format = 'binary'
-
-    else:
-        result = Schema(None,
-                        inclusion='unsupported',
-                        description=f'Unsupported column type {column_type}')
-    return result
-
-
-def create_column_metadata(cols):
-    mdata = {}
-    mdata = metadata.write(mdata, (), 'selected-by-default', False)
-    for col in cols:
-        schema = schema_for_column(col)
-        mdata = metadata.write(mdata,
-                               ('properties', col.column_name),
-                               'selected-by-default',
-                               schema.inclusion != 'unsupported')
-        mdata = metadata.write(mdata,
-                               ('properties', col.column_name),
-                               'sql-datatype',
-                               col.column_type.lower())
-
-    return metadata.to_list(mdata)
-
-
-def discover_catalog(mysql_conn, config):
-    """Returns a Catalog describing the structure of the database."""
-
-    filter_dbs_config = config.get('filter_dbs')
-
-    if filter_dbs_config:
-        filter_dbs_clause = ",".join([f"'{db_name}'" for db_name in filter_dbs_config.split(",")])
-
-        table_schema_clause = f"WHERE table_schema IN ({filter_dbs_clause})"
-    else:
-        table_schema_clause = """
-        WHERE table_schema NOT IN (
-        'information_schema',
-        'performance_schema',
-        'mysql',
-        'sys'
-        )"""
-
-    with connect_with_backoff(mysql_conn) as open_conn:
-        with open_conn.cursor() as cur:
-            cur.execute(f"""
-            SELECT table_schema,
-                   table_name,
-                   table_type,
-                   table_rows
-                FROM information_schema.tables
-                {table_schema_clause}
-            """)
-
-            table_info = {}
-
-            for (db_name, table, table_type, rows) in cur.fetchall():
-                if db_name not in table_info:
-                    table_info[db_name] = {}
-
-                table_info[db_name][table] = {
-                    'row_count': rows,
-                    'is_view': table_type == 'VIEW'
-                }
-
-            cur.execute(f"""
-                SELECT table_schema,
-                       table_name,
-                       column_name,
-                       data_type,
-                       character_maximum_length,
-                       numeric_precision,
-                       numeric_scale,
-                       column_type,
-                       column_key
-                    FROM information_schema.columns
-                    {table_schema_clause}
-                    ORDER BY table_schema, table_name
-            """)
-
-            columns = []
-            rec = cur.fetchone()
-            while rec is not None:
-                columns.append(Column(*rec))
-                rec = cur.fetchone()
-
-            entries = []
-            for (k, cols) in itertools.groupby(columns, lambda c: (c.table_schema, c.table_name)):
-                cols = list(cols)
-                (table_schema, table_name) = k
-                schema = Schema(type='object',
-                                properties={c.column_name: schema_for_column(c) for c in cols})
-                mdata = create_column_metadata(cols)
-                md_map = metadata.to_map(mdata)
-
-                md_map = metadata.write(md_map,
-                                        (),
-                                        'database-name',
-                                        table_schema)
-
-                is_view = table_info[table_schema][table_name]['is_view']
-
-                if table_schema in table_info and table_name in table_info[table_schema]:
-                    row_count = table_info[table_schema][table_name].get('row_count')
-
-                    if row_count is not None:
-                        md_map = metadata.write(md_map,
-                                                (),
-                                                'row-count',
-                                                row_count)
-
-                    md_map = metadata.write(md_map,
-                                            (),
-                                            'is-view',
-                                            is_view)
-
-                column_is_key_prop = lambda c, s: (c.column_key == 'PRI' and
-                                                   s.properties[c.column_name].inclusion != 'unsupported')
-
-                key_properties = [c.column_name for c in cols if column_is_key_prop(c, schema)]
-
-                if not is_view:
-                    md_map = metadata.write(md_map,
-                                            (),
-                                            'table-key-properties',
-                                            key_properties)
-
-                entry = CatalogEntry(
-                    table=table_name,
-                    stream=table_name,
-                    metadata=metadata.to_list(md_map),
-                    tap_stream_id=common.generate_tap_stream_id(table_schema, table_name),
-                    schema=schema)
-
-                entries.append(entry)
-
-    return Catalog(entries)
-
 
 def do_discover(mysql_conn, config):
-    discover_catalog(mysql_conn, config).dump()
-
-
-def desired_columns(selected, table_schema):
-    '''Return the set of column names we need to include in the SELECT.
-
-    selected - set of column names marked as selected in the input catalog
-    table_schema - the most recently discovered Schema for the table
-    '''
-    all_columns = set()
-    available = set()
-    automatic = set()
-    unsupported = set()
-
-    for column, column_schema in table_schema.properties.items():
-        all_columns.add(column)
-        inclusion = column_schema.inclusion
-        if inclusion == 'automatic':
-            automatic.add(column)
-        elif inclusion == 'available':
-            available.add(column)
-        elif inclusion == 'unsupported':
-            unsupported.add(column)
-        else:
-            raise Exception('Unknown inclusion ' + inclusion)
-
-    selected_but_unsupported = selected.intersection(unsupported)
-    if selected_but_unsupported:
-        LOGGER.warning(
-            'Columns %s were selected but are not supported. Skipping them.',
-            selected_but_unsupported)
-
-    selected_but_nonexistent = selected.difference(all_columns)
-    if selected_but_nonexistent:
-        LOGGER.warning(
-            'Columns %s were selected but do not exist.',
-            selected_but_nonexistent)
-
-    not_selected_but_automatic = automatic.difference(selected)
-    if not_selected_but_automatic:
-        LOGGER.warning(
-            'Columns %s are primary keys but were not selected. Adding them.',
-            not_selected_but_automatic)
-
-    return selected.intersection(available).union(automatic)
+    discover_catalog(mysql_conn, config.get('filter_dbs')).dump()
 
 
 def log_engine(mysql_conn, catalog_entry):
@@ -353,43 +92,6 @@ def binlog_stream_requires_historical(catalog_entry, state):
     return True
 
 
-def resolve_catalog(discovered_catalog, streams_to_sync):
-    result = Catalog(streams=[])
-
-    # Iterate over the streams in the input catalog and match each one up
-    # with the same stream in the discovered catalog.
-    for catalog_entry in streams_to_sync:
-        catalog_metadata = metadata.to_map(catalog_entry.metadata)
-        replication_key = catalog_metadata.get((), {}).get('replication-key')
-
-        discovered_table = discovered_catalog.get_stream(catalog_entry.tap_stream_id)
-        database_name = common.get_database_name(catalog_entry)
-
-        if not discovered_table:
-            LOGGER.warning('Database %s table %s was selected but does not exist',
-                           database_name, catalog_entry.table)
-            continue
-
-        selected = {k for k, v in catalog_entry.schema.properties.items()
-                    if common.property_is_selected(catalog_entry, k) or k == replication_key}
-
-        # These are the columns we need to select
-        columns = desired_columns(selected, discovered_table.schema)
-
-        result.streams.append(CatalogEntry(
-            tap_stream_id=catalog_entry.tap_stream_id,
-            metadata=catalog_entry.metadata,
-            stream=catalog_entry.tap_stream_id,
-            table=catalog_entry.table,
-            schema=Schema(
-                type='object',
-                properties={col: discovered_table.schema.properties[col]
-                            for col in columns}
-            )
-        ))
-
-    return result
-
 
 def get_non_binlog_streams(mysql_conn, catalog, config, state):
     '''Returns the Catalog of data we're going to sync for all SELECT-based
@@ -411,7 +113,7 @@ def get_non_binlog_streams(mysql_conn, catalog, config, state):
       3. any streams that do not have a replication method of LOG_BASED
 
     '''
-    discovered = discover_catalog(mysql_conn, config)
+    discovered = discover_catalog(mysql_conn, config.get('filter_dbs'))
 
     # Filter catalog to include only selected streams
     selected_streams = list(filter(common.stream_is_selected, catalog.streams))
@@ -465,7 +167,7 @@ def get_non_binlog_streams(mysql_conn, catalog, config, state):
 
 
 def get_binlog_streams(mysql_conn, catalog, config, state):
-    discovered = discover_catalog(mysql_conn, config)
+    discovered = discover_catalog(mysql_conn, config.get('filter_dbs'))
 
     selected_streams = list(filter(common.stream_is_selected, catalog.streams))
     binlog_streams = []
@@ -479,19 +181,6 @@ def get_binlog_streams(mysql_conn, catalog, config, state):
 
     return resolve_catalog(discovered, binlog_streams)
 
-
-def write_schema_message(catalog_entry, bookmark_properties=None):
-    if bookmark_properties is None:
-        bookmark_properties = []
-
-    key_properties = common.get_key_properties(catalog_entry)
-
-    singer.write_message(singer.SchemaMessage(
-        stream=catalog_entry.stream,
-        schema=catalog_entry.schema.to_dict(),
-        key_properties=key_properties,
-        bookmark_properties=bookmark_properties
-    ))
 
 
 def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
@@ -512,7 +201,7 @@ def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
-def do_sync_historical_binlog(mysql_conn, config, catalog_entry, state, columns):
+def do_sync_historical_binlog(mysql_conn, catalog_entry, state, columns):
     binlog.verify_binlog_config(mysql_conn)
 
     is_view = common.get_is_view(catalog_entry)
@@ -630,7 +319,7 @@ def sync_non_binlog_streams(mysql_conn, non_binlog_catalog, config, state):
             if replication_method == 'INCREMENTAL':
                 do_sync_incremental(mysql_conn, catalog_entry, state, columns)
             elif replication_method == 'LOG_BASED':
-                do_sync_historical_binlog(mysql_conn, config, catalog_entry, state, columns)
+                do_sync_historical_binlog(mysql_conn, catalog_entry, state, columns)
             elif replication_method == 'FULL_TABLE':
                 do_sync_full_table(mysql_conn, catalog_entry, state, columns)
             else:

--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -1,0 +1,317 @@
+# pylint: disable=missing-docstring,too-many-locals
+
+import collections
+import itertools
+import pendulum
+import pymysql
+
+from typing import Optional, Dict
+from singer import metadata, Schema, get_logger
+from singer.catalog import Catalog, CatalogEntry
+
+from tap_mysql.connection import connect_with_backoff
+from tap_mysql.sync_strategies import common
+
+
+LOGGER = get_logger('tap_mysql')
+
+
+Column = collections.namedtuple('Column', [
+    "table_schema",
+    "table_name",
+    "column_name",
+    "data_type",
+    "character_maximum_length",
+    "numeric_precision",
+    "numeric_scale",
+    "column_type",
+    "column_key"])
+
+
+pymysql.converters.conversions[pendulum.Pendulum] = pymysql.converters.escape_datetime
+
+STRING_TYPES = {'char', 'enum', 'longtext', 'mediumtext', 'text', 'varchar'}
+
+BYTES_FOR_INTEGER_TYPE = {
+    'tinyint': 1,
+    'smallint': 2,
+    'mediumint': 3,
+    'int': 4,
+    'bigint': 8
+}
+
+FLOAT_TYPES = {'float', 'double'}
+
+DATETIME_TYPES = {'datetime', 'timestamp', 'date', 'time'}
+
+BINARY_TYPES = {'binary', 'varbinary'}
+
+
+def discover_catalog(mysql_conn: Dict, dbs: str = None, tables: Optional[str] = None):
+    """Returns a Catalog describing the structure of the database."""
+
+    if dbs:
+        filter_dbs_clause = ",".join([f"'{db_name}'" for db_name in dbs.split(",")])
+        table_schema_clause = f"WHERE table_schema IN ({filter_dbs_clause})"
+    else:
+        table_schema_clause = """
+        WHERE table_schema NOT IN (
+        'information_schema',
+        'performance_schema',
+        'mysql',
+        'sys'
+        )"""
+
+    tables_clause = ''
+
+    if tables is not None and tables != '':
+        filter_tables_clause = ",".join([f"'{table_name}'" for table_name in tables.split(",")])
+        tables_clause = f" AND table_name IN ({filter_tables_clause})"
+
+    with connect_with_backoff(mysql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+            cur.execute(f"""
+            SELECT table_schema,
+                   table_name,
+                   table_type,
+                   table_rows
+                FROM information_schema.tables
+                {table_schema_clause}{tables_clause}
+            """)
+
+            table_info = {}
+
+            for (db_name, table, table_type, rows) in cur.fetchall():
+                if db_name not in table_info:
+                    table_info[db_name] = {}
+
+                table_info[db_name][table] = {
+                    'row_count': rows,
+                    'is_view': table_type == 'VIEW'
+                }
+
+            cur.execute(f"""
+                SELECT table_schema,
+                       table_name,
+                       column_name,
+                       data_type,
+                       character_maximum_length,
+                       numeric_precision,
+                       numeric_scale,
+                       column_type,
+                       column_key
+                    FROM information_schema.columns
+                    {table_schema_clause}{tables_clause}
+                    ORDER BY table_schema, table_name
+            """)
+
+            columns = []
+            rec = cur.fetchone()
+            while rec is not None:
+                columns.append(Column(*rec))
+                rec = cur.fetchone()
+
+            entries = []
+            for (k, cols) in itertools.groupby(columns, lambda c: (c.table_schema, c.table_name)):
+                cols = list(cols)
+                (table_schema, table_name) = k
+
+                schema = Schema(type='object',
+                                properties={c.column_name: schema_for_column(c) for c in cols})
+                mdata = create_column_metadata(cols)
+                md_map = metadata.to_map(mdata)
+
+                md_map = metadata.write(md_map,
+                                        (),
+                                        'database-name',
+                                        table_schema)
+
+                is_view = table_info[table_schema][table_name]['is_view']
+
+                if table_schema in table_info and table_name in table_info[table_schema]:
+                    row_count = table_info[table_schema][table_name].get('row_count')
+
+                    if row_count is not None:
+                        md_map = metadata.write(md_map,
+                                                (),
+                                                'row-count',
+                                                row_count)
+
+                    md_map = metadata.write(md_map,
+                                            (),
+                                            'is-view',
+                                            is_view)
+
+                column_is_key_prop = lambda c, s: (c.column_key == 'PRI' and
+                                                   s.properties[c.column_name].inclusion != 'unsupported')
+
+                key_properties = [c.column_name for c in cols if column_is_key_prop(c, schema)]
+
+                if not is_view:
+                    md_map = metadata.write(md_map,
+                                            (),
+                                            'table-key-properties',
+                                            key_properties)
+
+                entry = CatalogEntry(
+                    table=table_name,
+                    stream=table_name,
+                    metadata=metadata.to_list(md_map),
+                    tap_stream_id=common.generate_tap_stream_id(table_schema, table_name),
+                    schema=schema)
+
+                entries.append(entry)
+
+    return Catalog(entries)
+
+def schema_for_column(column):
+    """Returns the Schema object for the given Column."""
+    data_type = column.data_type.lower()
+    column_type = column.column_type.lower()
+
+    inclusion = 'available'
+    # We want to automatically include all primary key columns
+    if column.column_key.lower() == 'pri':
+        inclusion = 'automatic'
+
+    result = Schema(inclusion=inclusion)
+
+    if data_type == 'bit' or column_type.startswith('tinyint(1)'):
+        result.type = ['null', 'boolean']
+
+    elif data_type in BYTES_FOR_INTEGER_TYPE:
+        result.type = ['null', 'integer']
+        bits = BYTES_FOR_INTEGER_TYPE[data_type] * 8
+        if 'unsigned' in column.column_type:
+            result.minimum = 0
+            result.maximum = 2 ** bits - 1
+        else:
+            result.minimum = 0 - 2 ** (bits - 1)
+            result.maximum = 2 ** (bits - 1) - 1
+
+    elif data_type in FLOAT_TYPES:
+        result.type = ['null', 'number']
+
+    elif data_type == 'json':
+        result.type = ['null', 'object']
+
+    elif data_type == 'decimal':
+        result.type = ['null', 'number']
+        result.multipleOf = 10 ** (0 - column.numeric_scale)
+        return result
+
+    elif data_type in STRING_TYPES:
+        result.type = ['null', 'string']
+        result.maxLength = column.character_maximum_length
+
+    elif data_type in DATETIME_TYPES:
+        result.type = ['null', 'string']
+        result.format = 'date-time'
+
+    elif data_type in BINARY_TYPES:
+        result.type = ['null', 'string']
+        result.format = 'binary'
+
+    else:
+        result = Schema(None,
+                        inclusion='unsupported',
+                        description=f'Unsupported column type {column_type}')
+    return result
+
+
+def create_column_metadata(cols):
+    mdata = {}
+    mdata = metadata.write(mdata, (), 'selected-by-default', False)
+    for col in cols:
+        schema = schema_for_column(col)
+        mdata = metadata.write(mdata,
+                               ('properties', col.column_name),
+                               'selected-by-default',
+                               schema.inclusion != 'unsupported')
+        mdata = metadata.write(mdata,
+                               ('properties', col.column_name),
+                               'sql-datatype',
+                               col.column_type.lower())
+
+    return metadata.to_list(mdata)
+
+
+def resolve_catalog(discovered_catalog, streams_to_sync):
+    result = Catalog(streams=[])
+
+    # Iterate over the streams in the input catalog and match each one up
+    # with the same stream in the discovered catalog.
+    for catalog_entry in streams_to_sync:
+        catalog_metadata = metadata.to_map(catalog_entry.metadata)
+        replication_key = catalog_metadata.get((), {}).get('replication-key')
+
+        discovered_table = discovered_catalog.get_stream(catalog_entry.tap_stream_id)
+        database_name = common.get_database_name(catalog_entry)
+
+        if not discovered_table:
+            LOGGER.warning('Database %s table %s was selected but does not exist',
+                           database_name, catalog_entry.table)
+            continue
+
+        selected = {k for k, v in catalog_entry.schema.properties.items()
+                    if common.property_is_selected(catalog_entry, k) or k == replication_key}
+
+        # These are the columns we need to select
+        columns = desired_columns(selected, discovered_table.schema)
+
+        result.streams.append(CatalogEntry(
+            tap_stream_id=catalog_entry.tap_stream_id,
+            metadata=catalog_entry.metadata,
+            stream=catalog_entry.tap_stream_id,
+            table=catalog_entry.table,
+            schema=Schema(
+                type='object',
+                properties={col: discovered_table.schema.properties[col]
+                            for col in columns}
+            )
+        ))
+
+    return result
+
+def desired_columns(selected, table_schema):
+    '''Return the set of column names we need to include in the SELECT.
+
+    selected - set of column names marked as selected in the input catalog
+    table_schema - the most recently discovered Schema for the table
+    '''
+    all_columns = set()
+    available = set()
+    automatic = set()
+    unsupported = set()
+
+    for column, column_schema in table_schema.properties.items():
+        all_columns.add(column)
+        inclusion = column_schema.inclusion
+        if inclusion == 'automatic':
+            automatic.add(column)
+        elif inclusion == 'available':
+            available.add(column)
+        elif inclusion == 'unsupported':
+            unsupported.add(column)
+        else:
+            raise Exception('Unknown inclusion ' + inclusion)
+
+    selected_but_unsupported = selected.intersection(unsupported)
+    if selected_but_unsupported:
+        LOGGER.warning(
+            'Columns %s were selected but are not supported. Skipping them.',
+            selected_but_unsupported)
+
+    selected_but_nonexistent = selected.difference(all_columns)
+    if selected_but_nonexistent:
+        LOGGER.warning(
+            'Columns %s were selected but do not exist.',
+            selected_but_nonexistent)
+
+    not_selected_but_automatic = automatic.difference(selected)
+    if not_selected_but_automatic:
+        LOGGER.warning(
+            'Columns %s are primary keys but were not selected. Adding them.',
+            not_selected_but_automatic)
+
+    return selected.intersection(available).union(automatic)

--- a/tap_mysql/stream_utils.py
+++ b/tap_mysql/stream_utils.py
@@ -1,0 +1,39 @@
+# pylint: disable=missing-docstring,too-many-locals
+
+import singer
+
+from singer import metadata
+
+
+def write_schema_message(catalog_entry, bookmark_properties=None):
+    if bookmark_properties is None:
+        bookmark_properties = []
+
+    key_properties = get_key_properties(catalog_entry)
+
+    singer.write_message(singer.SchemaMessage(
+        stream=catalog_entry.stream,
+        schema=catalog_entry.schema.to_dict(),
+        key_properties=key_properties,
+        bookmark_properties=bookmark_properties
+    ))
+
+
+def get_key_properties(catalog_entry):
+    catalog_metadata = metadata.to_map(catalog_entry.metadata)
+    stream_metadata = catalog_metadata.get((), {})
+
+    is_view = get_is_view(catalog_entry)
+
+    if is_view:
+        key_properties = stream_metadata.get('view-key-properties', [])
+    else:
+        key_properties = stream_metadata.get('table-key-properties', [])
+
+    return key_properties
+
+
+def get_is_view(catalog_entry):
+    md_map = metadata.to_map(catalog_entry.metadata)
+
+    return md_map.get((), {}).get('is-view')

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -7,6 +7,8 @@ import time
 
 from singer import metadata, utils, metrics
 
+from tap_mysql.stream_utils import get_key_properties
+
 LOGGER = singer.get_logger('tap_mysql')
 
 
@@ -54,20 +56,6 @@ def get_database_name(catalog_entry):
     md_map = metadata.to_map(catalog_entry.metadata)
 
     return md_map.get((), {}).get('database-name')
-
-
-def get_key_properties(catalog_entry):
-    catalog_metadata = metadata.to_map(catalog_entry.metadata)
-    stream_metadata = catalog_metadata.get((), {})
-
-    is_view = get_is_view(catalog_entry)
-
-    if is_view:
-        key_properties = stream_metadata.get('view-key-properties', [])
-    else:
-        key_properties = stream_metadata.get('table-key-properties', [])
-
-    return key_properties
 
 
 def generate_select_sql(catalog_entry, columns):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,7 @@ def get_test_connection(extra_config=None):
 
 
 def discover_catalog(connection, catalog):
-    catalog = tap_mysql.discover_catalog(connection, catalog)
+    catalog = tap_mysql.discover_catalog(connection, catalog.get('filter_dbs'))
     streams = []
 
     for stream in catalog.streams:


### PR DESCRIPTION
## Problem

When columns get added/renamed in the source tables, tap-mysql, during binlog replication, starts sending the new data in the RECORD messages but doesn't send new SCHEMA message before that. This results in the target connector ignoring the data in these columns because the target table is not up to date , and we lose data in the newly added/renamed columns.

## Suggested Solution
Detect new columns, incl renamed one, by comparing the columns in the binlog event to the stream schema, and if they are any additional columns, run discovery and send a new SCHEMA message to target.

## Notes
* moved some function to their dedicated `*_utils.py` file for reusability and modularisation.
* Added test to make sure the changes work. 
