### PR TITLE
[AP-742] Fix error after new discovery 

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -302,7 +302,6 @@ def handle_update_rows_event(event, catalog_entry, state, columns, rows_saved, t
 def handle_delete_rows_event(event, catalog_entry, state, columns, rows_saved, time_extracted):
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
     db_column_types = get_db_column_types(event)
-    db_column_types[SDC_DELETED_AT] = 15 # set _sdc_deleted_at as a varchar column
 
     for row in event.rows:
         event_ts = datetime.datetime.utcfromtimestamp(event.timestamp).replace(tzinfo=pytz.UTC)

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -803,8 +803,9 @@ class TestBinlogReplication(unittest.TestCase):
 
         with connect_with_backoff(self.conn) as open_conn:
             with open_conn.cursor() as cursor:
+                cursor.execute('ALTER TABLE binlog_1 add column data blob;')
                 cursor.execute('ALTER TABLE binlog_1 add column is_cancelled boolean;')
-                cursor.execute('INSERT INTO binlog_1 (id, updated, is_cancelled) VALUES (2, \'2017-06-20\', true)')
+                cursor.execute('INSERT INTO binlog_1 (id, updated, is_cancelled, data) VALUES (2, \'2017-06-20\', true, \'blob content\')')
                 cursor.execute('INSERT INTO binlog_1 (id, updated, is_cancelled) VALUES (3, \'2017-09-21\', false)')
                 cursor.execute('INSERT INTO binlog_2 (id, updated) VALUES (3, \'2017-12-10\')')
                 cursor.execute('ALTER TABLE binlog_1 change column updated date_updated datetime;')


### PR DESCRIPTION
## Problem 
The tap fails sometimes with error 
```
TypeError: argument of type 'NoneType' is not iterable
```
in the function `tap_mysql/sync_strategies/binlog.py:row_to_singer_record`

### Investigation
The cause of this error is after a new change is detected in schema during LOG_BASED, the desired columns are not updated properly thus the rows are not filtered properly to ignore unsupported type columns, in this case a `blob`.

## Solution
As part of the updating schema, update the columns list to contains only supported type columns.

## Further notes
After deleting  a column, old binlog events will refer to this column with `__dropped_col_{SOME_INT}__`, we don't care about these cases when detecting new changes, so we filter out these columns with the regex pattern `r'__dropped_col_\d+__'`.

