### PR TITLE
[AP-742] Drop unsupported properties from new schema before flushing

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -302,7 +302,6 @@ def handle_update_rows_event(event, catalog_entry, state, columns, rows_saved, t
 def handle_delete_rows_event(event, catalog_entry, state, columns, rows_saved, time_extracted):
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
     db_column_types = get_db_column_types(event)
-    db_column_types[SDC_DELETED_AT] = 15 # set _sdc_deleted_at as a varchar column
 
     for row in event.rows:
         event_ts = datetime.datetime.utcfromtimestamp(event.timestamp).replace(tzinfo=pytz.UTC)

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -803,8 +803,9 @@ class TestBinlogReplication(unittest.TestCase):
 
         with connect_with_backoff(self.conn) as open_conn:
             with open_conn.cursor() as cursor:
+                cursor.execute('ALTER TABLE binlog_1 add column data blob;')
                 cursor.execute('ALTER TABLE binlog_1 add column is_cancelled boolean;')
-                cursor.execute('INSERT INTO binlog_1 (id, updated, is_cancelled) VALUES (2, \'2017-06-20\', true)')
+                cursor.execute('INSERT INTO binlog_1 (id, updated, is_cancelled, data) VALUES (2, \'2017-06-20\', true, \'blob content\')')
                 cursor.execute('INSERT INTO binlog_1 (id, updated, is_cancelled) VALUES (3, \'2017-09-21\', false)')
                 cursor.execute('INSERT INTO binlog_2 (id, updated) VALUES (3, \'2017-12-10\')')
                 cursor.execute('ALTER TABLE binlog_1 change column updated date_updated datetime;')

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -751,6 +751,13 @@ class TestBinlogReplication(unittest.TestCase):
         config['server_id'] = "100"
 
         tap_mysql.do_sync(self.conn, config, self.catalog, self.state)
+
+        schema_messages = list(filter(lambda m: isinstance(m, singer.SchemaMessage), SINGER_MESSAGES))
+
+        for schema_msg in schema_messages:
+            for prop, val in schema_msg.schema['properties'].items():
+                self.assertIn('type', val, f'property "{prop}" has no "type" in stream "{schema_msg.stream}"')
+
         record_messages = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))
 
         message_types = [type(m) for m in SINGER_MESSAGES]
@@ -814,6 +821,12 @@ class TestBinlogReplication(unittest.TestCase):
             open_conn.commit()
 
         tap_mysql.do_sync(self.conn, config, self.catalog, self.state)
+
+        schema_messages = list(filter(lambda m: isinstance(m, singer.SchemaMessage), SINGER_MESSAGES))
+
+        for schema_msg in schema_messages:
+            for prop, val in schema_msg.schema['properties'].items():
+                self.assertIn('type', val, f'property "{prop}" has no "type" in stream "{schema_msg.stream}"')
 
         record_messages = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))
 


### PR DESCRIPTION
## Problem
New schema after discovery contains properties of unsupported types. These properties don't have `type` which makes the targets fail because they expect every property to have a `type` property.

The error caused in target is:
```
    if list(v.values())[0][0]['type'] == 'string':
TypeError: string indices must be integers
```
Example of published schema message after a new column of type `blob` which is unsupported has been added:
```
SchemaMessage(type=SCHEMA, stream=tap_mysql_test-binlog_1, schema={'properties': {'id': {'inclusion': 'available', 'minimum': -2147483648, 'maximum': 2147483647, 'type': ['null', 'integer']}, 'date_updated': {'inclusion': 'available', 'format': 'date-time', 'type': ['null', 'string']}, 'data': {'inclusion': 'unsupported', 'description': 'Unsupported column type blob'}, 'is_cancelled': {'inclusion': 'available', 'type': ['null', 'boolean']}, '_sdc_deleted_at': {'format': 'date-time', 'type': ['null', 'string']}}, 'type': 'object'}, key_properties=[]),
``` 
notice the ` 'data': {'inclusion': 'unsupported', 'description': 'Unsupported column type blob'}`


## Solution
Remove these properties from schema before writing it to stdout.

## Further notes 
Added an if block to flush schema message only if new schema is different than original one.