### PR TITLE
[AP-774] Handle time data type separately

### DIFF
--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -12,9 +12,7 @@ from singer.catalog import Catalog, CatalogEntry
 from tap_mysql.connection import connect_with_backoff
 from tap_mysql.sync_strategies import common
 
-
 LOGGER = get_logger('tap_mysql')
-
 
 Column = collections.namedtuple('Column', [
     "table_schema",
@@ -26,7 +24,6 @@ Column = collections.namedtuple('Column', [
     "numeric_scale",
     "column_type",
     "column_key"])
-
 
 pymysql.converters.conversions[pendulum.Pendulum] = pymysql.converters.escape_datetime
 
@@ -164,8 +161,10 @@ def discover_catalog(mysql_conn: Dict, dbs: str = None, tables: Optional[str] = 
 
     return Catalog(entries)
 
-def schema_for_column(column):
+
+def schema_for_column(column): # pylint: disable=too-many-branches
     """Returns the Schema object for the given Column."""
+
     data_type = column.data_type.lower()
     column_type = column.column_type.lower()
 
@@ -276,6 +275,7 @@ def resolve_catalog(discovered_catalog, streams_to_sync):
         ))
 
     return result
+
 
 def desired_columns(selected, table_schema):
     '''Return the set of column names we need to include in the SELECT.

--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -42,7 +42,7 @@ BYTES_FOR_INTEGER_TYPE = {
 
 FLOAT_TYPES = {'float', 'double'}
 
-DATETIME_TYPES = {'datetime', 'timestamp', 'date', 'time'}
+DATETIME_TYPES = {'datetime', 'timestamp', 'date'}
 
 BINARY_TYPES = {'binary', 'varbinary'}
 
@@ -207,6 +207,10 @@ def schema_for_column(column):
     elif data_type in DATETIME_TYPES:
         result.type = ['null', 'string']
         result.format = 'date-time'
+
+    elif data_type == 'time':
+        result.type = ['null', 'string']
+        result.format = 'time'
 
     elif data_type in BINARY_TYPES:
         result.type = ['null', 'string']

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -89,6 +89,8 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
     row_to_persist = ()
     for idx, elem in enumerate(row):
         property_type = catalog_entry.schema.properties[columns[idx]].type
+        property_format = catalog_entry.schema.properties[columns[idx]].format
+
         if isinstance(elem, datetime.datetime):
             row_to_persist += (elem.isoformat() + '+00:00',)
 
@@ -96,9 +98,12 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
             row_to_persist += (elem.isoformat() + 'T00:00:00+00:00',)
 
         elif isinstance(elem, datetime.timedelta):
-            epoch = datetime.datetime.utcfromtimestamp(0)
-            timedelta_from_epoch = epoch + elem
-            row_to_persist += (timedelta_from_epoch.isoformat() + '+00:00',)
+            if property_format == 'time':
+                row_to_persist=(str(elem),) # this should convert time column into 'HH:MM:SS' formatted string
+            else:
+                epoch = datetime.datetime.utcfromtimestamp(0)
+                timedelta_from_epoch = epoch + elem
+                row_to_persist += (timedelta_from_epoch.isoformat() + '+00:00',)
 
         elif 'boolean' in property_type or property_type == 'boolean':
             if elem is None:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -206,7 +206,7 @@ class TestTypeMapping(unittest.TestCase):
     def test_time(self):
         self.assertEqual(self.schema.properties['c_time'],
                          Schema(['null', 'string'],
-                                format='date-time',
+                                format='time',
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_time'),
                          {'selected-by-default': True,


### PR DESCRIPTION
## Problem
Currently, when creating the stream's schema to be sent to targets, the `time` sql type is sent as a datetime format, it should be instead sent as time format to make the target table as identical as possible to the source once.

## Solution
Process time differently by setting format to `time` and properly format it the values when creating a singer record.

 