### PR TITLE
[NO-REF] Support MySQL spatial types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,11 @@ ENV/
 # Emacs
 .tramp_history
 
+# Singer
 config.json
+properties.json
+catalog.json
+state.json
+
+# IDE
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='pipelinewise-tap-mysql',
           'PyMySQL==0.7.11',
           'mysql-replication==0.21',
           'pyyaml==5.3',
+          'plpygis==0.2.0',
       ],
       extras_require={
           'test': [

--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -43,6 +43,10 @@ DATETIME_TYPES = {'datetime', 'timestamp', 'date'}
 
 BINARY_TYPES = {'binary', 'varbinary'}
 
+SPATIAL_TYPES = {'geometry', 'point', 'linestring',
+                 'polygon', 'multipoint', 'multilinestring',
+                 'multipolygon', 'geometrycollection'}
+
 
 def discover_catalog(mysql_conn: Dict, dbs: str = None, tables: Optional[str] = None):
     """Returns a Catalog describing the structure of the database."""
@@ -162,7 +166,7 @@ def discover_catalog(mysql_conn: Dict, dbs: str = None, tables: Optional[str] = 
     return Catalog(entries)
 
 
-def schema_for_column(column): # pylint: disable=too-many-branches
+def schema_for_column(column):  # pylint: disable=too-many-branches
     """Returns the Schema object for the given Column."""
 
     data_type = column.data_type.lower()
@@ -214,6 +218,10 @@ def schema_for_column(column): # pylint: disable=too-many-branches
     elif data_type in BINARY_TYPES:
         result.type = ['null', 'string']
         result.format = 'binary'
+
+    elif data_type in SPATIAL_TYPES:
+        result.type = ['null', 'string']
+        result.format = 'spatial'
 
     else:
         result = Schema(None,

--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -220,7 +220,7 @@ def schema_for_column(column):  # pylint: disable=too-many-branches
         result.format = 'binary'
 
     elif data_type in SPATIAL_TYPES:
-        result.type = ['null', 'string']
+        result.type = ['null', 'object']
         result.format = 'spatial'
 
     else:

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -74,7 +74,11 @@ def generate_select_sql(catalog_entry, columns):
         # if the column format is binary, fetch the values after removing any trailing
         # null bytes 0x00 and hexifying the column.
         if 'binary' == property_format:
-            escaped_columns.append(f'hex(trim(trailing CHAR(0x00) from {escaped_col})) as {escaped_col}')
+            escaped_columns.append(
+                f'hex(trim(trailing CHAR(0x00) from {escaped_col})) as {escaped_col}')
+        if 'spatial' == property_format:
+            escaped_columns.append(
+                f'ST_AsGeoJSON({escaped_col}) as {escaped_col}')
         else:
             escaped_columns.append(escaped_col)
 

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -76,7 +76,7 @@ def generate_select_sql(catalog_entry, columns):
         if 'binary' == property_format:
             escaped_columns.append(
                 f'hex(trim(trailing CHAR(0x00) from {escaped_col})) as {escaped_col}')
-        if 'spatial' == property_format:
+        elif 'spatial' == property_format:
             escaped_columns.append(
                 f'ST_AsGeoJSON({escaped_col}) as {escaped_col}')
         else:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -56,7 +56,15 @@ class TestTypeMapping(unittest.TestCase):
                 c_bit BIT(4),
                 c_date DATE,
                 c_time TIME,
-                c_year YEAR
+                c_year YEAR,
+                c_geometry GEOMETRY,
+                c_point POINT,
+                c_linestring LINESTRING,
+                c_polygon POLYGON,
+                c_multipoint MULTIPOINT,
+                c_multilinestring MULTILINESTRING,
+                c_multipolygon MULTIPOLYGON,
+                c_geometrycollection GEOMETRYCOLLECTION
                 )''')
 
         catalog = test_utils.discover_catalog(conn, {})
@@ -223,6 +231,78 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(
             self.schema.properties['c_pk'].inclusion,
             'automatic')
+
+    def test_geometry(self):
+        self.assertEqual(self.schema.properties['c_geometry'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_geometry'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'geometry'})
+
+    def test_point(self):
+        self.assertEqual(self.schema.properties['c_point'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_point'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'point'})
+
+    def test_linestring(self):
+        self.assertEqual(self.schema.properties['c_linestring'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_linestring'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'linestring'})
+
+    def test_polygon(self):
+        self.assertEqual(self.schema.properties['c_polygon'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_polygon'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'polygon'})
+
+    def test_multipoint(self):
+        self.assertEqual(self.schema.properties['c_multipoint'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_multipoint'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'multipoint'})
+
+    def test_multilinestring(self):
+        self.assertEqual(self.schema.properties['c_multilinestring'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_multilinestring'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'multilinestring'})
+
+    def test_multipolygon(self):
+        self.assertEqual(self.schema.properties['c_multipolygon'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_multipolygon'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'multipolygon'})
+
+    def test_geometrycollection(self):
+        self.assertEqual(self.schema.properties['c_geometrycollection'],
+                         Schema(['null', 'object'],
+                                format='spatial',
+                                inclusion='available'))
+        self.assertEqual(self.get_metadata_for_column('c_geometrycollection'),
+                         {'selected-by-default': True,
+                          'sql-datatype': 'geometrycollection'})
 
 
 class TestSelectsAppropriateColumns(unittest.TestCase):
@@ -481,7 +561,7 @@ class TestIncrementalReplication(unittest.TestCase):
                      'selected': True,
                      'table-key-properties': [],
                      'database-name': 'tap_mysql_test'
-                 }},
+                }},
                 {'breadcrumb': ('properties', 'val'), 'metadata': {'selected': True}}
             ]
 
@@ -634,7 +714,7 @@ class TestBinlogReplication(unittest.TestCase):
                      'selected': True,
                      'database-name': 'tap_mysql_test',
                      'table-key-propertes': ['id']
-                 }},
+                }},
                 {'breadcrumb': ('properties', 'id'), 'metadata': {'selected': True}},
                 {'breadcrumb': ('properties', 'updated'), 'metadata': {'selected': True}}
             ]
@@ -845,8 +925,8 @@ class TestBinlogReplication(unittest.TestCase):
                           singer.RecordMessage,
                           singer.RecordMessage,
                           singer.RecordMessage,
-                          singer.StateMessage, # end of 1st sync
-                          singer.StateMessage, # start of 2nd sync
+                          singer.StateMessage,  # end of 1st sync
+                          singer.StateMessage,  # start of 2nd sync
                           singer.SchemaMessage,
                           singer.SchemaMessage,
                           singer.SchemaMessage,
@@ -956,7 +1036,7 @@ class TestEscaping(unittest.TestCase):
                  'selected': True,
                  'table-key-properties': [],
                  'database-name': 'tap_mysql_test'
-             }},
+            }},
             {'breadcrumb': ('properties', 'b c'), 'metadata': {'selected': True}}
         ]
 
@@ -1023,6 +1103,7 @@ class TestSupportedPK(unittest.TestCase):
                                "(BINARY('d'), 40)")
 
         self.catalog = test_utils.discover_catalog(self.conn, {})
+        print(f"CATALOOOOOG: {self.catalog.to_dict()}")
 
     def test_primary_key_is_in_metadata(self):
         primary_keys = {}
@@ -1039,7 +1120,7 @@ class TestSupportedPK(unittest.TestCase):
         global SINGER_MESSAGES
         SINGER_MESSAGES.clear()
 
-        #inital sync
+        # inital sync
         tap_mysql.do_sync(self.conn, {}, self.catalog, {})
 
         # get schema message to test that it has all the table's columns
@@ -1098,6 +1179,7 @@ class MySQLConnectionMock(MySQLConnection):
     """
     Mocked MySQLConnection class
     """
+
     def __init__(self, config):
         super().__init__(config)
 
@@ -1167,7 +1249,7 @@ class TestSessionSqls(unittest.TestCase):
 
 
 class TestBitBooleanMapping(unittest.TestCase):
-    
+
     def setUp(self):
         self.conn = test_utils.get_test_connection()
 
@@ -1180,7 +1262,6 @@ class TestBitBooleanMapping(unittest.TestCase):
                     "(3, b'0010')")
 
         self.catalog = test_utils.discover_catalog(self.conn, {})
-
 
     def test_sync_messages_are_correct(self):
 
@@ -1200,7 +1281,6 @@ class TestBitBooleanMapping(unittest.TestCase):
             {'id': 2, 'c_bit': None},
             {'id': 3, 'c_bit': True},
         ], [rec.record for rec in record_messages])
-
 
     def tearDown(self) -> None:
         with connect_with_backoff(self.conn) as open_conn:

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -1103,7 +1103,6 @@ class TestSupportedPK(unittest.TestCase):
                                "(BINARY('d'), 40)")
 
         self.catalog = test_utils.discover_catalog(self.conn, {})
-        print(f"CATALOOOOOG: {self.catalog.to_dict()}")
 
     def test_primary_key_is_in_metadata(self):
         primary_keys = {}


### PR DESCRIPTION
## Context

`pipelinewise-tap-mysql` currently doesn't support MySQL [spatial data types](https://dev.mysql.com/doc/refman/5.7/en/spatial-type-overview.html)

### Changes

This change adds support for spatial data types by converting them to geojson by using MySQLs `ST_AsGeoJSON` function for `FULL_TABLE` and `INCREMENTAL` syncs and `plpygis` to convert `wbk` to geojson for `LOG_BASED` syncs.

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
