### PR TITLE
Bump pylint from 2.4 to 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='pipelinewise-tap-mysql',
       extras_require={
           'test': [
               'nose==1.3.*',
-              'pylint==2.4.*',
+              'pylint==2.6.0',
               'nose-cov==1.6'
           ]
       },

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -291,7 +291,7 @@ def do_sync_full_table(mysql_conn, catalog_entry, state, columns):
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
-def sync_non_binlog_streams(mysql_conn, non_binlog_catalog, config, state):
+def sync_non_binlog_streams(mysql_conn, non_binlog_catalog, state):
     for catalog_entry in non_binlog_catalog.streams:
         columns = list(catalog_entry.schema.properties.keys())
 
@@ -342,7 +342,7 @@ def do_sync(mysql_conn, config, catalog, state):
     non_binlog_catalog = get_non_binlog_streams(mysql_conn, catalog, config, state)
     binlog_catalog = get_binlog_streams(mysql_conn, catalog, config, state)
 
-    sync_non_binlog_streams(mysql_conn, non_binlog_catalog, config, state)
+    sync_non_binlog_streams(mysql_conn, non_binlog_catalog, state)
     sync_binlog_streams(mysql_conn, binlog_catalog, config, state)
 
 


### PR DESCRIPTION
## Problem

Dependabot is about to upgrade pylint 2.4 to 2.6.0 in [this PR](https://github.com/transferwise/pipelinewise-tap-mysql/pull/47) but the new pylint gives error:

```
tap_mysql/__init__.py:294: [W0613(unused-argument), sync_non_binlog_streams] Unused argument 'config'
```

## Proposed changes

Bump pylint and fix pylint error

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
