### PR TITLE
[AP-859] Stop constant discovery when running into known unsupported column types 

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -92,9 +92,9 @@ def binlog_stream_requires_historical(catalog_entry, state):
     return True
 
 
-
 def get_non_binlog_streams(mysql_conn, catalog, config, state):
-    '''Returns the Catalog of data we're going to sync for all SELECT-based
+    """
+    Returns the Catalog of data we're going to sync for all SELECT-based
     streams (i.e. INCREMENTAL, FULL_TABLE, and LOG_BASED that require a historical
     sync). LOG_BASED streams that require a historical sync are inferred from lack
     of any state.
@@ -106,13 +106,13 @@ def get_non_binlog_streams(mysql_conn, catalog, config, state):
 
     The resulting Catalog will include the following any streams marked as
     "selected" that currently exist in the database. Columns marked as "selected"
-    and those labled "automatic" (e.g. primary keys and replication keys) will be
+    and those labeled "automatic" (e.g. primary keys and replication keys) will be
     included. Streams will be prioritized in the following order:
       1. currently_syncing if it is SELECT-based
       2. any streams that do not have state
       3. any streams that do not have a replication method of LOG_BASED
 
-    '''
+    """
     discovered = discover_catalog(mysql_conn, config.get('filter_dbs'))
 
     # Filter catalog to include only selected streams
@@ -180,7 +180,6 @@ def get_binlog_streams(mysql_conn, catalog, config, state):
             binlog_streams.append(stream)
 
     return resolve_catalog(discovered, binlog_streams)
-
 
 
 def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
@@ -330,12 +329,14 @@ def sync_non_binlog_streams(mysql_conn, non_binlog_catalog, state):
 
 
 def sync_binlog_streams(mysql_conn, binlog_catalog, config, state):
+
     if binlog_catalog.streams:
         for stream in binlog_catalog.streams:
             write_schema_message(stream)
 
         with metrics.job_timer('sync_binlog'):
-            binlog.sync_binlog_stream(mysql_conn, config, binlog_catalog.streams, state)
+            binlog_streams_map = binlog.generate_streams_map(binlog_catalog.streams)
+            binlog.sync_binlog_stream(mysql_conn, config, binlog_streams_map, state)
 
 
 def do_sync(mysql_conn, config, catalog, state):

--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -92,7 +92,7 @@ def is_supported_column_type(column_sql_type: str) -> bool:
         # fetch only the substring from start till the parentheses
         truncated_sql_type = column_sql_type[:idx].lower()
 
-    # The above should process should never result in an empty string
+    # The above process should never result in an empty string
     # so to err on the safe side, let's raise an exception in case that ever happens
     if not truncated_sql_type:
         raise Exception(

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -313,10 +313,10 @@ def handle_delete_rows_event(event, catalog_entry, state, columns, rows_saved, t
     stream_version = common.get_stream_version(catalog_entry.tap_stream_id, state)
     db_column_types = get_db_column_types(event)
 
-    for row in event.rows:
-        event_ts = datetime.datetime.utcfromtimestamp(event.timestamp) \
-            .replace(tzinfo=pytz.UTC).isoformat()
+    event_ts = datetime.datetime.utcfromtimestamp(event.timestamp) \
+        .replace(tzinfo=pytz.UTC).isoformat()
 
+    for row in event.rows:
         vals = row['values']
         vals[SDC_DELETED_AT] = event_ts
 

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -64,7 +64,7 @@ def generate_select_sql(catalog_entry, columns):
     escaped_table = escape(catalog_entry.table)
     escaped_columns = []
 
-    for idx, col_name in enumerate(columns):
+    for col_name in columns:
         # wrap the column name in "`"
         escaped_col = escape(col_name)
 
@@ -73,10 +73,10 @@ def generate_select_sql(catalog_entry, columns):
 
         # if the column format is binary, fetch the values after removing any trailing
         # null bytes 0x00 and hexifying the column.
-        if 'binary' == property_format:
+        if property_format == 'binary':
             escaped_columns.append(
                 f'hex(trim(trailing CHAR(0x00) from {escaped_col})) as {escaped_col}')
-        elif 'spatial' == property_format:
+        elif property_format == 'spatial':
             escaped_columns.append(
                 f'ST_AsGeoJSON({escaped_col}) as {escaped_col}')
         else:
@@ -112,7 +112,7 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
         elif 'boolean' in property_type or property_type == 'boolean':
             if elem is None:
                 boolean_representation = None
-            elif elem == 0 or elem == b'\x00':
+            elif elem in (0, b'\x00'):
                 boolean_representation = False
             else:
                 boolean_representation = True

--- a/tests/test_tap_mysql.py
+++ b/tests/test_tap_mysql.py
@@ -81,7 +81,8 @@ class TestTypeMapping(unittest.TestCase):
                                 multipleOf=1))
         self.assertEqual(self.get_metadata_for_column('c_decimal'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'decimal(10,0)'})
+                          'sql-datatype': 'decimal(10,0)',
+                          'datatype': 'decimal'})
 
     def test_decimal_unsigned(self):
         self.assertEqual(self.schema.properties['c_decimal_2_unsigned'],
@@ -90,7 +91,8 @@ class TestTypeMapping(unittest.TestCase):
                                 multipleOf=0.01))
         self.assertEqual(self.get_metadata_for_column('c_decimal_2_unsigned'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'decimal(5,2) unsigned'})
+                          'sql-datatype': 'decimal(5,2) unsigned',
+                          'datatype': 'decimal'})
 
     def test_decimal_with_defined_scale_and_precision(self):
         self.assertEqual(self.schema.properties['c_decimal_2'],
@@ -99,7 +101,8 @@ class TestTypeMapping(unittest.TestCase):
                                 multipleOf=0.01))
         self.assertEqual(self.get_metadata_for_column('c_decimal_2'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'decimal(11,2)'})
+                          'sql-datatype': 'decimal(11,2)',
+                          'datatype': 'decimal'})
 
     def test_tinyint(self):
         self.assertEqual(self.schema.properties['c_tinyint'],
@@ -109,7 +112,8 @@ class TestTypeMapping(unittest.TestCase):
                                 maximum=127))
         self.assertEqual(self.get_metadata_for_column('c_tinyint'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'tinyint(4)'})
+                          'sql-datatype': 'tinyint(4)',
+                          'datatype': 'tinyint'})
 
     def test_tinyint_1(self):
         self.assertEqual(self.schema.properties['c_tinyint_1'],
@@ -117,7 +121,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_tinyint_1'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'tinyint(1)'})
+                          'sql-datatype': 'tinyint(1)',
+                          'datatype': 'tinyint'})
 
     def test_tinyint_1_unsigned(self):
         self.assertEqual(self.schema.properties['c_tinyint_1_unsigned'],
@@ -125,7 +130,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_tinyint_1_unsigned'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'tinyint(1) unsigned'})
+                          'sql-datatype': 'tinyint(1) unsigned',
+                          'datatype': 'tinyint'})
 
     def test_smallint(self):
         self.assertEqual(self.schema.properties['c_smallint'],
@@ -135,7 +141,8 @@ class TestTypeMapping(unittest.TestCase):
                                 maximum=32767))
         self.assertEqual(self.get_metadata_for_column('c_smallint'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'smallint(6)'})
+                          'sql-datatype': 'smallint(6)',
+                          'datatype': 'smallint'})
 
     def test_mediumint(self):
         self.assertEqual(self.schema.properties['c_mediumint'],
@@ -145,7 +152,8 @@ class TestTypeMapping(unittest.TestCase):
                                 maximum=8388607))
         self.assertEqual(self.get_metadata_for_column('c_mediumint'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'mediumint(9)'})
+                          'sql-datatype': 'mediumint(9)',
+                          'datatype': 'mediumint'})
 
     def test_int(self):
         self.assertEqual(self.schema.properties['c_int'],
@@ -155,7 +163,8 @@ class TestTypeMapping(unittest.TestCase):
                                 maximum=2147483647))
         self.assertEqual(self.get_metadata_for_column('c_int'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'int(11)'})
+                          'sql-datatype': 'int(11)',
+                          'datatype': 'int'})
 
     def test_bigint(self):
         self.assertEqual(self.schema.properties['c_bigint'],
@@ -165,7 +174,8 @@ class TestTypeMapping(unittest.TestCase):
                                 maximum=9223372036854775807))
         self.assertEqual(self.get_metadata_for_column('c_bigint'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'bigint(20)'})
+                          'sql-datatype': 'bigint(20)',
+                          'datatype': 'bigint'})
 
     def test_bigint_unsigned(self):
         self.assertEqual(self.schema.properties['c_bigint_unsigned'],
@@ -176,7 +186,8 @@ class TestTypeMapping(unittest.TestCase):
 
         self.assertEqual(self.get_metadata_for_column('c_bigint_unsigned'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'bigint(20) unsigned'})
+                          'sql-datatype': 'bigint(20) unsigned',
+                          'datatype': 'bigint'})
 
     def test_float(self):
         self.assertEqual(self.schema.properties['c_float'],
@@ -184,7 +195,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_float'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'float'})
+                          'sql-datatype': 'float',
+                          'datatype': 'float'})
 
     def test_double(self):
         self.assertEqual(self.schema.properties['c_double'],
@@ -192,7 +204,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_double'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'double'})
+                          'sql-datatype': 'double',
+                          'datatype': 'double'})
 
     def test_bit(self):
         self.assertEqual(self.schema.properties['c_bit'],
@@ -200,7 +213,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_bit'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'bit(4)'})
+                          'sql-datatype': 'bit(4)',
+                          'datatype': 'bit'})
 
     def test_date(self):
         self.assertEqual(self.schema.properties['c_date'],
@@ -209,7 +223,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_date'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'date'})
+                          'sql-datatype': 'date',
+                          'datatype': 'date'})
 
     def test_time(self):
         self.assertEqual(self.schema.properties['c_time'],
@@ -218,14 +233,16 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_time'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'time'})
+                          'sql-datatype': 'time',
+                          'datatype': 'time'})
 
     def test_year(self):
         self.assertEqual(self.schema.properties['c_year'].inclusion,
                          'unsupported')
         self.assertEqual(self.get_metadata_for_column('c_year'),
                          {'selected-by-default': False,
-                          'sql-datatype': 'year(4)'})
+                          'sql-datatype': 'year(4)',
+                          'datatype': 'year'})
 
     def test_pk(self):
         self.assertEqual(
@@ -239,7 +256,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_geometry'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'geometry'})
+                          'sql-datatype': 'geometry',
+                          'datatype': 'geometry'})
 
     def test_point(self):
         self.assertEqual(self.schema.properties['c_point'],
@@ -248,7 +266,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_point'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'point'})
+                          'sql-datatype': 'point',
+                          'datatype': 'point'})
 
     def test_linestring(self):
         self.assertEqual(self.schema.properties['c_linestring'],
@@ -257,7 +276,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_linestring'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'linestring'})
+                          'sql-datatype': 'linestring',
+                          'datatype': 'linestring'})
 
     def test_polygon(self):
         self.assertEqual(self.schema.properties['c_polygon'],
@@ -266,7 +286,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_polygon'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'polygon'})
+                          'sql-datatype': 'polygon',
+                          'datatype': 'polygon'})
 
     def test_multipoint(self):
         self.assertEqual(self.schema.properties['c_multipoint'],
@@ -275,7 +296,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_multipoint'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'multipoint'})
+                          'sql-datatype': 'multipoint',
+                          'datatype': 'multipoint'})
 
     def test_multilinestring(self):
         self.assertEqual(self.schema.properties['c_multilinestring'],
@@ -284,7 +306,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_multilinestring'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'multilinestring'})
+                          'sql-datatype': 'multilinestring',
+                          'datatype': 'multilinestring'})
 
     def test_multipolygon(self):
         self.assertEqual(self.schema.properties['c_multipolygon'],
@@ -293,7 +316,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_multipolygon'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'multipolygon'})
+                          'sql-datatype': 'multipolygon',
+                          'datatype': 'multipolygon'})
 
     def test_geometrycollection(self):
         self.assertEqual(self.schema.properties['c_geometrycollection'],
@@ -302,7 +326,8 @@ class TestTypeMapping(unittest.TestCase):
                                 inclusion='available'))
         self.assertEqual(self.get_metadata_for_column('c_geometrycollection'),
                          {'selected-by-default': True,
-                          'sql-datatype': 'geometrycollection'})
+                          'sql-datatype': 'geometrycollection',
+                          'datatype': 'geometrycollection'})
 
 
 class TestSelectsAppropriateColumns(unittest.TestCase):


### PR DESCRIPTION
## Problem

In LOG_BASED replication, changes to a table structure are detected by analysing columns in binlog events.
When a unsupported column is in the stream, that causes the discovery to run over and over again, adding unnecessary overhead to the sync.  

## Proposed changes
* add datatype to properties breadcrumbs
* Aggregate all supported columns in a global variable.
* Added a new function `is_supported_column_type` that analyses the column datatype and checks if it's supported.
* Only run discovery mid-sync if detected columns are of supported types or new columns that we don't know anything about.
* Keep a set of ignored columns at runtime to not have to check whether we need to ignore a column or not every single time. 

PS: Every binlog event has list of columns, with their name and types ..etc, the column type though uses the values from [FIELD_TYPE](https://github.com/noplay/python-mysql-replication/blob/main/pymysqlreplication/constants/FIELD_TYPE.py) where different sql types might share the same integer ID, which is undesirable so we cannot use these type to reliabilty know and analyse a column type to check if it's supported, hence why I resorted to properties breadcrumbs, e.g:
```
{
          "breadcrumb": [
            "properties",
            "c_varchar"
          ],
          "metadata": {
            "selected-by-default": true,
            "sql-datatype": "varchar(100)",
             "datatype": "varchar"
          }
        }
```


PSS: To keep PR small, I left out the tests that I've done because they introduce some refactoring.
Will send the PR some other time

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions