### PR TITLE
Log error message for session SQLs

### DIFF
--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -39,8 +39,8 @@ def run_session_sqls(connection):
         for sql in session_sqls:
             try:
                 run_sql(connection, sql)
-            except pymysql.err.InternalError:
-                warnings.append(f'Could not set session variable: {sql}')
+            except pymysql.err.InternalError as exc:
+                warnings.append(f'Could not set session variable `{sql}`: {exc}')
 
     if warnings:
         LOGGER.warning('Encountered non-fatal errors when configuring session that could impact performance:')


### PR DESCRIPTION
## Problem

When setting session SQL such as connection timeouts, it's possible
to get an error like

```
 (1229, "Variable 'connect_timeout' is a GLOBAL variable and should be
 set. with SET GLOBAL")
 ```

The previous error handling just swallowed MySQL error messages,
making it difficult or impossible to debug errors with connection
settings.

## Proposed changes

Add a simple change to log the DB error message, so that errors
can be diagnosed more easily.




## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions