### PR TITLE
AP-1116 Add support for logical replication with GTID for MySQL

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -249,8 +249,7 @@ def do_sync_historical_binlog(mysql_conn, catalog_entry, state, columns, use_gti
 
         current_gtid = None
         if use_gtid:
-            server_id = fetch_server_id(mysql_conn)
-            current_gtid = binlog.fetch_current_gtid_pos(mysql_conn, str(server_id), engine)
+            current_gtid = binlog.fetch_current_gtid_pos(mysql_conn, engine)
 
         state = singer.write_bookmark(state,
                                       catalog_entry.tap_stream_id,

--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -207,6 +207,9 @@ def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
 def do_sync_historical_binlog(mysql_conn, catalog_entry, state, columns, use_gtid: bool, engine: str):
     binlog.verify_binlog_config(mysql_conn)
 
+    if use_gtid and engine == MYSQL_ENGINE:
+        binlog.verify_gtid_config(mysql_conn)
+
     is_view = common.get_is_view(catalog_entry)
 
     if is_view:

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -175,3 +175,19 @@ def fetch_server_id(mysql_conn: MySQLConnection) -> int:
             server_id = cur.fetchone()[0]
 
             return server_id
+
+
+def fetch_server_uuid(mysql_conn: MySQLConnection) -> str:
+    """
+    Finds server UUID
+    Args:
+        mysql_conn: Mysql connection instance
+
+    Returns: server UUID
+    """
+    with connect_with_backoff(mysql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+            cur.execute("SELECT @@server_uuid")
+            server_uuid = cur.fetchone()[0]
+
+            return server_uuid

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -80,6 +80,23 @@ def verify_binlog_config(mysql_conn):
                                 f"not set to 'FULL': {binlog_row_image}.")
 
 
+def verify_gtid_config(mysql_conn: MySQLConnection):
+    """
+    Checks if GTID is enabled, raises exception if it's not
+    Args:
+        mysql_conn: instance of MySQLConnection
+
+    Returns: None if gtid is enabled
+    """
+    with connect_with_backoff(mysql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+            cur.execute("select @@gtid_mode;")
+            binlog_format = cur.fetchone()[0]
+
+            if binlog_format != 'ON':
+                raise Exception('Unable to replicate binlog stream because GTID mode is not enabled.')
+
+
 def fetch_current_log_file_and_pos(mysql_conn):
     with connect_with_backoff(mysql_conn) as open_conn:
         with open_conn.cursor() as cur:

--- a/tests/unit/sync_strategies/test_binlog.py
+++ b/tests/unit/sync_strategies/test_binlog.py
@@ -1749,6 +1749,55 @@ class TestBinlogSyncStrategy(TestCase):
         )
 
     @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
+    def test_verify_gtid_config_success(self, connect_with_backoff):
+
+        mysql_con = MagicMock(spec_set=MySQLConnection).return_value
+
+        cur_mock = MagicMock(spec_set=Cursor).return_value
+        cur_mock.__enter__.return_value.fetchone.side_effect = [
+            ['ON'],
+        ]
+
+        mysql_con.__enter__.return_value.cursor.return_value = cur_mock
+
+        connect_with_backoff.return_value = mysql_con
+
+        binlog.verify_gtid_config(mysql_con)
+
+        connect_with_backoff.assert_called_with(mysql_con)
+        cur_mock.__enter__.return_value.execute.assert_has_calls(
+            [
+                call('select @@gtid_mode;'),
+            ]
+        )
+
+    @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
+    def test_verify_gtid_config_fail_if_not_on(self, connect_with_backoff):
+
+        mysql_con = MagicMock(spec_set=MySQLConnection).return_value
+
+        cur_mock = MagicMock(spec_set=Cursor).return_value
+        cur_mock.__enter__.return_value.fetchone.side_effect = [
+            ['OFF'],
+        ]
+
+        mysql_con.__enter__.return_value.cursor.return_value = cur_mock
+
+        connect_with_backoff.return_value = mysql_con
+
+        with self.assertRaises(Exception) as ex:
+            binlog.verify_gtid_config(mysql_con)
+
+            self.assertEqual("Unable to replicate binlog stream because GTID mode is not enabled.")
+
+        connect_with_backoff.assert_called_with(mysql_con)
+        cur_mock.__enter__.return_value.execute.assert_has_calls(
+            [
+                call('select @@gtid_mode;'),
+            ]
+        )
+
+    @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
     def test_fetch_current_log_file_and_pos_success(self, connect_with_backoff):
         mysql_con = MagicMock(spec_set=MySQLConnection).return_value
         cur_mock = MagicMock(spec_set=Cursor).return_value
@@ -1795,45 +1844,67 @@ class TestBinlogSyncStrategy(TestCase):
             ]
         )
 
+    @patch('tap_mysql.sync_strategies.binlog.connection.fetch_server_uuid')
     @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
-    def test_fetch_current_gtid_pos_for_mariadb_success(self, connect_with_backoff):
+    def test_fetch_current_gtid_pos_for_mysql_not_found_expect_exception(
+            self, connect_with_backoff, fetch_server_uuid):
         mysql_con = MagicMock(spec_set=MySQLConnection).return_value
         cur_mock = MagicMock(spec_set=Cursor).return_value
         cur_mock.__enter__.return_value.fetchone.side_effect = [
-            ['0-1-647,0-2-143,0-3-1123'],
+            ['3E11FA47-71CA-11E1-9E21-C80AA9429562:1,3E11FA47-71BB-11E1-9E33-C80AA9429562:2:143,0-3-1123,,'
+             '3E11FA47-71CA-11E1-9E33-C80AA9429562:2:332'],
         ]
 
         mysql_con.__enter__.return_value.cursor.return_value = cur_mock
 
         connect_with_backoff.return_value = mysql_con
+        fetch_server_uuid.return_value = '3E11FA47-71CA-11E1-9E33-C80AA9429562'
 
-        result = binlog.fetch_current_gtid_pos(mysql_con, '2', connection.MARIADB_ENGINE)
-
-        self.assertEqual(result, '0-2-143')
+        with self.assertRaises(Exception):
+            binlog.fetch_current_gtid_pos(mysql_con, connection.MYSQL_ENGINE)
 
         connect_with_backoff.assert_called_with(mysql_con)
+        fetch_server_uuid.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
             [
-                call('select @@gtid_current_pos;'),
+                call('select @@GLOBAL.gtid_executed;'),
             ]
         )
 
+    @patch('tap_mysql.sync_strategies.binlog.connection.fetch_server_uuid')
     @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
-    def test_fetch_current_gtid_pos_for_mysql_fails(self, connect_with_backoff):
+    def test_fetch_current_gtid_pos_for_mysql_fails(
+            self, connect_with_backoff, fetch_server_uuid):
+
         mysql_con = MagicMock(spec_set=MySQLConnection).return_value
         cur_mock = MagicMock(spec_set=Cursor).return_value
+        cur_mock.__enter__.return_value.fetchone.side_effect = [
+            ['3E11FA47-71CA-11E1-9E33-C80AA9429562:1,3E11FA47-71BB-11E1-9E33-C80AA9429562:2:143,0-3-1123,,'
+             '3E11FA47-71CA-11E1-9E33-C80AA9429562:2:332'],
+        ]
+
         mysql_con.__enter__.return_value.cursor.return_value = cur_mock
 
         connect_with_backoff.return_value = mysql_con
+        fetch_server_uuid.return_value = '3E11FA47-71CA-11E1-9E33-C80AA9429562'
 
-        with self.assertRaises(NotImplementedError):
-            binlog.fetch_current_gtid_pos(mysql_con, '2', connection.MYSQL_ENGINE)
+        result = binlog.fetch_current_gtid_pos(mysql_con, connection.MYSQL_ENGINE)
+
+        self.assertEqual('3E11FA47-71CA-11E1-9E33-C80AA9429562:1', result)
 
         connect_with_backoff.assert_called_with(mysql_con)
-        cur_mock.__enter__.return_value.execute.assert_not_called()
+        fetch_server_uuid.assert_called_with(mysql_con)
 
+        cur_mock.__enter__.return_value.execute.assert_has_calls(
+            [
+                call('select @@GLOBAL.gtid_executed;'),
+            ]
+        )
+
+    @patch('tap_mysql.sync_strategies.binlog.connection.fetch_server_id')
     @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
-    def test_fetch_current_gtid_pos_no_gtid_found_expect_exception(self, connect_with_backoff):
+    def test_fetch_current_gtid_pos_for_mariadb_no_gtid_found_expect_exception(
+            self, connect_with_backoff, fetch_server_id):
         mysql_con = MagicMock(spec_set=MySQLConnection).return_value
         cur_mock = MagicMock(spec_set=Cursor).return_value
         cur_mock.__enter__.return_value.fetchone.side_effect = [
@@ -1843,21 +1914,27 @@ class TestBinlogSyncStrategy(TestCase):
         mysql_con.__enter__.return_value.cursor.return_value = cur_mock
 
         connect_with_backoff.return_value = mysql_con
+        fetch_server_id.return_value = 2
 
         with self.assertRaises(Exception) as ex:
-            binlog.fetch_current_gtid_pos(mysql_con, '2', connection.MARIADB_ENGINE)
+            binlog.fetch_current_gtid_pos(mysql_con, connection.MARIADB_ENGINE)
 
             self.assertIn('No suitable GTID was found for server', str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
+        fetch_server_id.assert_called_with(mysql_con)
+
         cur_mock.__enter__.return_value.execute.assert_has_calls(
             [
                 call('select @@gtid_current_pos;'),
             ]
         )
 
+    @patch('tap_mysql.sync_strategies.binlog.connection.fetch_server_id')
     @patch('tap_mysql.sync_strategies.binlog.connect_with_backoff')
-    def test_fetch_current_gtid_pos_no_gtid_found_for_given_server_expect_exception(self, connect_with_backoff):
+    def test_fetch_current_gtid_pos_no_gtid_found_for_given_server_expect_exception(
+            self, connect_with_backoff, fetch_server_id):
+
         mysql_con = MagicMock(spec_set=MySQLConnection).return_value
         cur_mock = MagicMock(spec_set=Cursor).return_value
         cur_mock.__enter__.return_value.fetchone.side_effect = [
@@ -1868,19 +1945,22 @@ class TestBinlogSyncStrategy(TestCase):
 
         connect_with_backoff.return_value = mysql_con
 
+        fetch_server_id.return_value = 2
+
         with self.assertRaises(Exception) as ex:
-            binlog.fetch_current_gtid_pos(mysql_con, '2', connection.MARIADB_ENGINE)
+            binlog.fetch_current_gtid_pos(mysql_con, connection.MARIADB_ENGINE)
 
             self.assertIn('No suitable GTID was found for server', str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
+        fetch_server_id.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
             [
                 call('select @@gtid_current_pos;'),
             ]
         )
 
-    def test_calculate_gtid_bookmark_returns_earliest(self):
+    def test_calculate_gtid_bookmark_for_mariadb_returns_earliest(self):
 
         binlog_streams = {
             'stream1': {'schema': {}},
@@ -1903,7 +1983,7 @@ class TestBinlogSyncStrategy(TestCase):
 
         self.assertEqual(result, '0-20-12')
 
-    def test_calculate_gtid_bookmark_no_gtid_found(self):
+    def test_calculate_gtid_bookmark_for_mariadb_no_gtid_found_expect_exception(self):
 
         binlog_streams = {
             'stream1': {'schema': {}},
@@ -1921,7 +2001,31 @@ class TestBinlogSyncStrategy(TestCase):
 
             self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))
 
-    def test_calculate_gtid_bookmark_for_mysql_not_implemented(self):
+    def test_calculate_gtid_bookmark_for_mysql_returns_earliest(self):
+
+        binlog_streams = {
+            'stream1': {'schema': {}},
+            'stream2': {'schema': {}},
+            'stream3': {'schema': {}},
+            'stream4': {'schema': {}},
+        }
+
+        state = {
+            'bookmarks': {
+                'stream1': {'gtid': '3E11FA47-71CA-11E1-9E33-C80AA9429562:1-165'},
+                'stream2': {'gtid': '3E11FA47-71CA-11E1-9E33-C80AA9429562:12'},
+                'stream3': {'gtid': '3E11FA47-71CA-11E1-9E33-C80AA9429562:1-43'},
+                'stream4': {'gtid': '3E11FA47-71CA-11E1-9E33-C80AA9429562:1-2'},
+                'stream6': {'gtid': '3E11FA47-71CA-11E1-9E33-C80AA9429562:1'},
+                'stream5': {},
+            }
+        }
+
+        result = binlog.calculate_gtid_bookmark(binlog_streams, state, connection.MYSQL_ENGINE)
+
+        self.assertEqual(result, '3E11FA47-71CA-11E1-9E33-C80AA9429562:1-2')
+
+    def test_calculate_gtid_bookmark_for_mysql_no_gtid_found_expect_exception(self):
 
         binlog_streams = {
             'stream1': {'schema': {}},
@@ -1934,5 +2038,7 @@ class TestBinlogSyncStrategy(TestCase):
             }
         }
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(Exception) as ex:
             binlog.calculate_gtid_bookmark(binlog_streams, state, connection.MYSQL_ENGINE)
+
+            self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -1,0 +1,59 @@
+import unittest
+
+from unittest.mock import patch, MagicMock, call
+
+from pymysql.cursors import Cursor
+from singer import CatalogEntry
+
+from tap_mysql.connection import MySQLConnection, fetch_server_id, fetch_server_uuid
+
+import tap_mysql.connection
+
+
+class TestConnection(unittest.TestCase):
+
+    @patch('tap_mysql.connection.connect_with_backoff')
+    def test_fetch_server_id(self, connect_with_backoff):
+
+        mysql_con = MagicMock(spec_set=MySQLConnection).return_value
+        cur_mock = MagicMock(spec_set=Cursor).return_value
+        cur_mock.__enter__.return_value.fetchone.return_value = [111]
+
+        mysql_con.__enter__.return_value.cursor.return_value = cur_mock
+
+        connect_with_backoff.return_value = mysql_con
+
+        result = fetch_server_id(mysql_con)
+
+        self.assertEqual(111, result)
+
+        connect_with_backoff.assert_called_with(mysql_con)
+
+        cur_mock.__enter__.return_value.execute.assert_has_calls(
+            [
+                call('select @@server_id;'),
+            ]
+        )
+
+    @patch('tap_mysql.connection.connect_with_backoff')
+    def test_fetch_server_uuid(self, connect_with_backoff):
+
+        mysql_con = MagicMock(spec_set=MySQLConnection).return_value
+        cur_mock = MagicMock(spec_set=Cursor).return_value
+        cur_mock.__enter__.return_value.fetchone.return_value = ['dkfhdsf0-ejr-dfbsf-dnfnsbdmfbdf']
+
+        mysql_con.__enter__.return_value.cursor.return_value = cur_mock
+
+        connect_with_backoff.return_value = mysql_con
+
+        result = fetch_server_uuid(mysql_con)
+
+        self.assertEqual('dkfhdsf0-ejr-dfbsf-dnfnsbdmfbdf', result)
+
+        connect_with_backoff.assert_called_with(mysql_con)
+
+        cur_mock.__enter__.return_value.execute.assert_has_calls(
+            [
+                call('select @@server_uuid;'),
+            ]
+        )


### PR DESCRIPTION
## Problem

Same as https://github.com/transferwise/pipelinewise-tap-mysql/pull/90 

## Proposed changes

Support Mysql's GTID format


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions