### PR TITLE
AP-1139 dynamically infer gtid from binlog coordinates for MariaDB 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pylint:
 
 unit_test:
 	. ./venv/bin/activate ;\
-	nosetests -c .noserc --cover-min-percentage=42 tests/unit
+	nosetests -c .noserc --cover-min-percentage=47 tests/unit
 
 integration_test:
 	. ./venv/bin/activate ;\

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -318,8 +318,11 @@ def calculate_gtid_bookmark(
 
         min_gtid = _find_gtid_by_binlog_coordinates(mysql_conn, log_file, log_pos)
 
-    LOGGER.info('The earliest bookmarked GTID found in the state is "%s", and will be used to resume replication',
-                min_gtid)
+        LOGGER.info('The inferred GTID is "%s", it will be used to resume replication',
+                    min_gtid)
+    else:
+        LOGGER.info('The earliest bookmarked GTID found in the state is "%s", and will be used to resume replication',
+                    min_gtid)
 
     return min_gtid
 

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -259,6 +259,7 @@ def row_to_singer_record(catalog_entry, version, db_column_map, row, time_extrac
 
 
 def calculate_gtid_bookmark(
+        mysql_conn: MySQLConnection,
         binlog_streams_map: Dict[str, Any],
         state: Dict,
         engine: str
@@ -266,6 +267,7 @@ def calculate_gtid_bookmark(
     """
     Finds the earliest bookmarked gtid in the state
     Args:
+        mysql_conn: instance of MySqlConnection
         binlog_streams_map: dictionary of selected streams
         state: state dict with bookmarks
         engine: the DB flavor mysql/mariadb
@@ -298,14 +300,46 @@ def calculate_gtid_bookmark(
                 min_seq_no = gtid_seq_no
                 min_gtid = gtid
 
-
     if not min_gtid:
-        raise Exception("Couldn't find any gtid in state bookmarks to resume logical replication")
+
+        # Mariadb has a handy sql function BINLOG_GTID_POS to infer the gtid position from given binlog coordinates so
+        # we will use that, as for mysql, there is no such thing, the only available option is using the cli utility
+        # mysqlbinlog which we deemed as not nice to use, and we don't wanna make it a system requirement of this tap,
+        # hence, this functionality of inferring gtid is not implemented for it.
+
+        if engine != connection.MARIADB_ENGINE:
+            raise Exception("Couldn't find any gtid in state bookmarks to resume logical replication")
+
+        LOGGER.info("Couldn't find a gtid in state, will try to infer one from binlog coordinates if they exist ..")
+        log_file, log_pos = calculate_bookmark(mysql_conn, binlog_streams_map, state)
+
+        if not (log_file and log_pos):
+            raise Exception("No binlog coordinates in state to infer gtid position! Cannot resume logical replication")
+
+        min_gtid = _find_gtid_by_binlog_coordinates(mysql_conn, log_file, log_pos)
 
     LOGGER.info('The earliest bookmarked GTID found in the state is "%s", and will be used to resume replication',
                 min_gtid)
 
     return min_gtid
+
+
+def _find_gtid_by_binlog_coordinates(mysql_conn: MySQLConnection, log_file: str, log_pos: int) -> str:
+    """
+    Finds the equivalent gtid position from the given binlog file and pos.
+    This only works on MariaDB
+
+    Args:
+        mysql_conn: instance of MySQLConnection
+        log_file: a binlog file
+        log_pos: a position in the log file
+
+    Returns: gtid position
+    """
+    with connect_with_backoff(mysql_conn) as open_conn:
+        with open_conn.cursor() as cur:
+            cur.execute(f"select BINLOG_GTID_POS('{log_file}', {log_pos});")
+            return cur.fetchone()[0]
 
 
 def get_min_log_pos_per_log_file(binlog_streams_map, state) -> Dict[str, Dict]:
@@ -808,7 +842,7 @@ def sync_binlog_stream(
     log_file = log_pos = gtid = None
 
     if config['use_gtid']:
-        gtid = calculate_gtid_bookmark(binlog_streams_map, state, config['engine'])
+        gtid = calculate_gtid_bookmark(mysql_conn, binlog_streams_map, state, config['engine'])
     else:
         log_file, log_pos = calculate_bookmark(mysql_conn, binlog_streams_map, state)
 

--- a/tests/integration/test_tap_mysql.py
+++ b/tests/integration/test_tap_mysql.py
@@ -835,7 +835,7 @@ class TestBinlogReplication(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             tap_mysql.do_sync(self.conn, {}, self.catalog, state)
 
-            self.assertEqual(expected_exception_message, str(context.exception))
+        self.assertEqual(expected_exception_message, str(context.exception))
 
     def test_fail_if_log_file_does_not_exist(self):
         log_file = 'chicken'
@@ -858,7 +858,7 @@ class TestBinlogReplication(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             tap_mysql.do_sync(self.conn, {}, self.catalog, state)
 
-            self.assertEqual(expected_exception_message, str(context.exception))
+        self.assertEqual(expected_exception_message, str(context.exception))
 
     def test_binlog_stream(self):
         global SINGER_MESSAGES
@@ -1097,7 +1097,7 @@ class TestBinlogReplication(unittest.TestCase):
         with self.assertRaises(Exception) as ex:
             tap_mysql.do_sync(self.conn, config, self.catalog, self.state)
 
-            self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))
+        self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))
 
     def test_binlog_stream_switching_from_binlog_to_gtid_with_mariadb_success(self):
         global SINGER_MESSAGES

--- a/tests/unit/sync_strategies/test_binlog.py
+++ b/tests/unit/sync_strategies/test_binlog.py
@@ -1673,9 +1673,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.verify_binlog_config(mysql_con)
 
-            self.assertEqual("Unable to replicate binlog stream because binlog_row_image is "
-                             f"not set to 'FULL': Not-FULL.",
-                             str())
+        self.assertEqual("Unable to replicate binlog stream because binlog_row_image is not set to 'FULL': Not-FULL.", str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
@@ -1702,9 +1700,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.verify_binlog_config(mysql_con)
 
-            self.assertEqual("Unable to replicate binlog stream because binlog_format is "
-                             f"not set to 'ROW': Not-ROW.",
-                             str())
+        self.assertEqual("Unable to replicate binlog stream because binlog_format is not set to 'ROW': Not-ROW.", str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
@@ -1735,10 +1731,10 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.verify_binlog_config(mysql_con)
 
-            self.assertEqual("Unable to replicate binlog stream because binlog_row_image "
-                             "system variable does not exist. MySQL version must be at "
-                             "least 5.6.2 to use binlog replication.",
-                             str())
+        self.assertEqual("Unable to replicate binlog stream because binlog_row_image "
+                         "system variable does not exist. MySQL version must be at "
+                         "least 5.6.2 to use binlog replication.",
+                         str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
@@ -1788,7 +1784,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.verify_gtid_config(mysql_con)
 
-            self.assertEqual("Unable to replicate binlog stream because GTID mode is not enabled.")
+        self.assertEqual("Unable to replicate binlog stream because GTID mode is not enabled.", str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
@@ -1835,7 +1831,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.fetch_current_log_file_and_pos(mysql_con)
 
-            self.assertEqual('MySQL binary logging is not enabled.', str(ex))
+        self.assertEqual('MySQL binary logging is not enabled.', str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         cur_mock.__enter__.return_value.execute.assert_has_calls(
@@ -1919,7 +1915,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.fetch_current_gtid_pos(mysql_con, connection.MARIADB_ENGINE)
 
-            self.assertIn('No suitable GTID was found for server', str(ex))
+        self.assertIn('No suitable GTID was found for server', str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         fetch_server_id.assert_called_with(mysql_con)
@@ -1950,7 +1946,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.fetch_current_gtid_pos(mysql_con, connection.MARIADB_ENGINE)
 
-            self.assertIn('No suitable GTID was found for server', str(ex))
+        self.assertIn('No suitable GTID was found for server', str(ex))
 
         connect_with_backoff.assert_called_with(mysql_con)
         fetch_server_id.assert_called_with(mysql_con)
@@ -2046,7 +2042,7 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.calculate_gtid_bookmark(mysql_conn, binlog_streams, state, connection.MARIADB_ENGINE)
 
-            self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))
+        self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))
 
     def test_calculate_gtid_bookmark_for_mysql_returns_earliest(self):
 
@@ -2089,4 +2085,4 @@ class TestBinlogSyncStrategy(TestCase):
         with self.assertRaises(Exception) as ex:
             binlog.calculate_gtid_bookmark(mysql_conn, binlog_streams, state, connection.MYSQL_ENGINE)
 
-            self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))
+        self.assertEqual("Couldn't find any gtid in state bookmarks to resume logical replication", str(ex))


### PR DESCRIPTION
## Problem

With the tap now having GTID support, switching to using GTID for bookmark requires a one-off task of finding the equivalent gtid and updating the state file, this can mean a lot of work if have numerous pipelines.

## Proposed changes

For MariaDB, when `use_gtid` flag is true and there is no gtid but there a binlog file and position in the state, then use that to lookup the equivalent gtid thanks to the sql function `BINLOG_GTID_POS`.

For Mysql, there is no such option, the closest is to use mysqlbinlog library which mean it would become a system requirement of this tap, we decided to just fail instead, so the user has to find the gtid position and manually update the state.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions