### PR TITLE
JSON and Spatial types need to be considered strings

### DIFF
--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -271,7 +271,7 @@ def schema_for_column(column):  # pylint: disable=too-many-branches
             result.multipleOf = 10 ** (0 - column.numeric_scale)
 
     elif data_type in JSON_TYPES:
-        result.type = ['null', 'object']
+        result.type = ['null', 'string']
 
     elif data_type in STRING_TYPES:
         result.type = ['null', 'string']

--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -290,7 +290,7 @@ def schema_for_column(column):  # pylint: disable=too-many-branches
         result.format = 'binary'
 
     elif data_type in SPATIAL_TYPES:
-        result.type = ['null', 'object']
+        result.type = ['null', 'string']
         result.format = 'spatial'
 
     else:


### PR DESCRIPTION
## Problem

Json and spatial columns are sent as string record, but defined as object type in the catalog. 
This causes a problem because targets expect an object record and not a string.

More details in [#99](https://github.com/transferwise/pipelinewise-tap-mysql/issues/99)

## Proposed changes

The columns of JSON and Spatial types are defined with type `["null", "string"]` in the catalog.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions