### PR TITLE
AP-1183: handle case when BINLOG_GTID_POS returns many comma separated gtids

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
           TAP_MYSQL_HOST: localhost
           TAP_MYSQL_ENGINE: mariadb
           LOGGING_CONF_FILE: ./sample_logging.conf
-        run: make integration_test
+        run: make integration_test extra_args=--cover-min-percentage=85
 
       - name: Shutdown db test container
         run: docker-compose down mariadb_server1
@@ -99,7 +99,7 @@ jobs:
           TAP_MYSQL_HOST: localhost
           TAP_MYSQL_ENGINE: mysql
           LOGGING_CONF_FILE: ./sample_logging.conf
-        run: make integration_test
+        run: make integration_test extra_args=--cover-min-percentage=84
 
       - name: Shutdown db test container
         run: docker-compose down mysql_server

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ pylint:
 
 unit_test:
 	. ./venv/bin/activate ;\
-	nosetests -c .noserc --cover-min-percentage=47 tests/unit
+	nosetests -c .noserc --cover-min-percentage=47 tests/unit $(extra_args)
 
 integration_test:
 	. ./venv/bin/activate ;\
-	nosetests -c .noserc --cover-min-percentage=85 tests/integration
+	nosetests -c .noserc tests/integration $(extra_args)

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -347,24 +347,24 @@ def _find_gtid_by_binlog_coordinates(mysql_conn: MySQLConnection, log_file: str,
             cur.execute(f"select BINLOG_GTID_POS('{log_file}', {log_pos});")
             gtids = cur.fetchone()[0]
 
-            LOGGER.info('BINLOG_GTID_POS -> gtids: %s', gtids)
+    LOGGER.debug('BINLOG_GTID_POS returned gtids: %s', gtids)
 
-            if not gtids:
-                return None
+    if not gtids:
+        return None
 
-            server_id = str(connection.fetch_server_id(mysql_conn))
+    server_id = str(connection.fetch_server_id(mysql_conn))
 
-            gtid_to_use = None
-            for gtid in gtids.split(','):
-                gtid_parts = gtid.split('-')
+    gtid_to_use = None
+    for gtid in gtids.split(','):
+        gtid_parts = gtid.split('-')
 
-                if len(gtid_parts) != 3:
-                    continue
+        if len(gtid_parts) != 3:
+            continue
 
-                if gtid_parts[1] == server_id:
-                    gtid_to_use = gtid
+        if gtid_parts[1] == server_id:
+            gtid_to_use = gtid
 
-            return gtid_to_use
+    return gtid_to_use
 
 
 def get_min_log_pos_per_log_file(binlog_streams_map, state) -> Dict[str, Dict]:


### PR DESCRIPTION
## Problem

When using mariadb DB and enabling GTID for a tap that has been using binlog coordinates, the code will try to lookup the equivalent GTID using the sql function `BINLOG_GTID_POS`, this function can return comma separated gtids which was not expected.

## Proposed changes

Process the results `BINLOG_GTID_POS` and find the right gtid by comparing the second element to host's server ID.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions