### PR TITLE
Calculate max/min for DECIMAL columns

### DIFF
--- a/tests/integration/test_tap_mysql.py
+++ b/tests/integration/test_tap_mysql.py
@@ -83,7 +83,10 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(self.schema.properties['c_decimal'],
                          Schema(['null', 'number'],
                                 inclusion='available',
-                                multipleOf=1))
+                                multipleOf=1,
+                                maximum=float('9'*10),  # Default is DECIMAL(10,0)
+                                minimum=-float('9'*10),
+                                ))
         self.assertEqual(self.get_metadata_for_column('c_decimal'),
                          {'selected-by-default': True,
                           'sql-datatype': 'decimal(10,0)',
@@ -93,7 +96,10 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(self.schema.properties['c_decimal_2_unsigned'],
                          Schema(['null', 'number'],
                                 inclusion='available',
-                                multipleOf=0.01))
+                                multipleOf=0.01,
+                                maximum=float('9'*3 + '.99'),
+                                minimum=0
+                                ),)
         self.assertEqual(self.get_metadata_for_column('c_decimal_2_unsigned'),
                          {'selected-by-default': True,
                           'sql-datatype': 'decimal(5,2) unsigned',
@@ -103,7 +109,10 @@ class TestTypeMapping(unittest.TestCase):
         self.assertEqual(self.schema.properties['c_decimal_2'],
                          Schema(['null', 'number'],
                                 inclusion='available',
-                                multipleOf=0.01))
+                                multipleOf=0.01,
+                                maximum=float('9'*9 + '.99'),
+                                minimum=-float('9'*9 + '.99'),
+                                ))
         self.assertEqual(self.get_metadata_for_column('c_decimal_2'),
                          {'selected-by-default': True,
                           'sql-datatype': 'decimal(11,2)',


### PR DESCRIPTION
## Problem

Targets must know the width of columns in order to be able to
correctly represent them. For example, BigQuery distinguishes
DECIMAL and BIGDECIMAL types, and a SQL database like target-mysql
or target-postgres would need to be able to reconstruct the actual
precision/scale values in order to be able to create a valid schema.


## Proposed changes

To encode the DECIMAL column as JSONSchema, use Python Decimal
machinery to calculate the Maximum/Minimum values of a decimal
with the specified precision.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Since this changes the output schema, I think it's probably a breaking change. Some targets might not be able to handle a modification to the schema.

## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions