### PR TITLE
issue-129/cursorclass default argument string now converted into pyth…

### DIFF
--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -94,11 +94,10 @@ class MySQLConnection(pymysql.connections.Connection):
         }
 
         # Convert the string representation of the class to the class itself
-        if config.get('cursorclass'):
+        args['cursorclass'] = pymysql.cursors.SSCursor
+        if config.get('cursorclass') and type(config.get('cursorclass')) == str:
             modules = config.get('cursorclass').rsplit('.', 1)
             args['cursorclass'] = getattr(sys.modules[modules[0]], modules[1])
-        else:
-            args['cursorclass'] = pymysql.cursors.SSCursor
 
         ssl_arg = None
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -94,8 +94,8 @@ class MySQLConnection(pymysql.connections.Connection):
         }
 
         # Convert the string representation of the class to the class itself
-        args['cursorclass'] = pymysql.cursors.SSCursor
-        if config.get('cursorclass') and type(config.get('cursorclass')) == str:
+        args['cursorclass'] = config.get('cursorclass') or pymysql.cursors.SSCursor
+        if  type(config.get('cursorclass')) == str:
             modules = config.get('cursorclass').rsplit('.', 1)
             args['cursorclass'] = getattr(sys.modules[modules[0]], modules[1])
 

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -5,6 +5,7 @@ import backoff
 import pymysql
 import ssl
 import singer
+import sys
 
 from pymysql.constants import CLIENT
 
@@ -88,10 +89,16 @@ class MySQLConnection(pymysql.connections.Connection):
             "password": config["password"],
             "host": config["host"],
             "port": int(config["port"]),
-            "cursorclass": config.get("cursorclass") or pymysql.cursors.SSCursor,
             "connect_timeout": CONNECT_TIMEOUT_SECONDS,
             "charset": "utf8",
         }
+
+        # Convert the string representation of the class to the class itself
+        if config.get('cursorclass'):
+            modules = config.get('cursorclass').rsplit('.', 1)
+            args['cursorclass'] = getattr(sys.modules[modules[0]], modules[1])
+        else:
+            args['cursorclass'] = pymysql.cursors.SSCursor
 
         ssl_arg = None
 


### PR DESCRIPTION
…on class

## Problem

_Describe the problem your PR is trying to solve_
See [ISSUE-129](https://github.com/transferwise/pipelinewise-tap-mysql/issues/129). In short, the `cursorclass` config value is returned to the connection class as a string and later down the line that cursor is executed, which errors out into a `str not callable`-error. 

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This PR fixes the above issue by converting the provided cursor class reference represented as a string into an actual python class.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions