### PR TITLE
parse json columns to python objects

### DIFF
--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 import singer
 import time
+import json
 
 from singer import metadata, utils, metrics
 
@@ -117,6 +118,9 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
             else:
                 boolean_representation = True
             row_to_persist += (boolean_representation,)
+
+        elif 'object' in property_type or property_type == 'object':
+            row_to_persist += (json.loads(elem),)
 
         else:
             row_to_persist += (elem,)

--- a/tests/integration/test_tap_mysql.py
+++ b/tests/integration/test_tap_mysql.py
@@ -1272,7 +1272,7 @@ class TestJsonTables(unittest.TestCase):
 
         record_message = list(filter(lambda m: isinstance(m, singer.RecordMessage), SINGER_MESSAGES))[0]
         self.assertTrue(isinstance(record_message, singer.RecordMessage))
-        self.assertEqual(record_message.record, {'val': '{"a": 10, "b": "c"}'})
+        self.assertEqual(record_message.record, {'val': {'a': 10, 'b': 'c'}})
 
 
 class TestSupportedPK(unittest.TestCase):


### PR DESCRIPTION
## Problem

Currently the schema for json columns is `object`, but the actual value emitted is a string. 

## Proposed changes

The schema and the records need to match eachother. This change resolved this bug by making the record match the schema.

This is covered in issue [99](https://github.com/transferwise/pipelinewise-tap-mysql/issues/99). The open PR ([101](https://github.com/transferwise/pipelinewise-tap-mysql/pull/101)) to make the schema match the record. This isn't as favourable because it means json parsing must be done again on the target side.

I'm not very familiar with spatial datatypes in MySQL, so I can't say how this will affect them. I'm happy to write some tests if someone could point to an example of what they should look like.

## Types of changes

When a column has `object` as one of it's type, it will be parsed from a json string to a python dict.
This may result in a `JSONDecodeError` if the json is malformatted.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Unit tests for changes (not needed for documentation changes)
- [X] CI checks pass with my changes
- [X] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions