### PR TITLE
fix(binlog.py): Fix maximum server_id

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -809,7 +809,7 @@ def create_binlog_stream_reader(
         server_id = int(config.get('server_id'))
         LOGGER.info("Using provided server_id=%s", server_id)
     else:
-        server_id = random.randint(1, 2 ^ 32)  # generate random server id for this slave
+        server_id = random.randint(1, 2 ** 32 - 1)  # generate random server id for this slave
         LOGGER.info("Using randomly generated server_id=%s", server_id)
 
     engine = config['engine']


### PR DESCRIPTION
## Problem

The current range for server_id is too small and causes collisions with other instances of the tap that might be running

## Proposed changes

Set the maximum accepted value to 2 ** 32 - 1

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [-] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [-] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [-] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [-] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [-] Relevant documentation is updated including usage instructions