### PR TITLE
Prefer SSL connection to source

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @transferwise/analytics-platform

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mysql',
-      version='1.5.6',
+      version='1.6.0',
       description='Singer.io tap for extracting data from MySQL & MariaDB - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_mysql/connection.py
+++ b/tap_mysql/connection.py
@@ -93,7 +93,7 @@ class MySQLConnection(pymysql.connections.Connection):
             "charset": "utf8",
         }
 
-        ssl_arg = None
+        ssl_arg = {"": True}
 
         if config.get("database"):
             args["database"] = config["database"]

--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -809,7 +809,7 @@ def create_binlog_stream_reader(
         server_id = int(config.get('server_id'))
         LOGGER.info("Using provided server_id=%s", server_id)
     else:
-        server_id = random.randint(1, 2 ^ 32)  # generate random server id for this slave
+        server_id = random.randint(1, 2 ** 32 - 1)  # generate random server id for this slave
         LOGGER.info("Using randomly generated server_id=%s", server_id)
 
     engine = config['engine']


### PR DESCRIPTION
## Context

Currently, tap-mysql will only connect without SSL, unless certificates are specified. Going forward, source servers really need to be protected a little better if possible.

## Proposed changes

Attempt SSL connection without certificate before falling back to regular connections


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions