### PR TITLE
Allow schema overrides coming from input catalog

### DIFF
--- a/tap_mysql/discover_utils.py
+++ b/tap_mysql/discover_utils.py
@@ -352,7 +352,7 @@ def resolve_catalog(discovered_catalog, streams_to_sync):
             table=catalog_entry.table,
             schema=Schema(
                 type='object',
-                properties={col: discovered_table.schema.properties[col]
+                properties={col: catalog_entry.schema.properties[col]
                             for col in columns}
             )
         ))


### PR DESCRIPTION
## Context

Catalog schema overrides are ignored. Passing a catalog file with some schema overrides, e.g. adding `format` to a string field to inform the target about the specific type of string, wasn't supported.

## Problem

The reason was that the sync process re-discovers the catalog even when an input file is provided in order to prevent selection of items not present in the database.

## Proposed changes

Emit the schema message with the input schema, rather than the re-discovered one.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions