### PR TITLE
Fix output format of time fields

### DIFF
--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -103,7 +103,10 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
 
         elif isinstance(elem, datetime.timedelta):
             if property_format == 'time':
-                row_to_persist += (str(elem),) # this should convert time column into 'HH:MM:SS' formatted string
+                _total_seconds = int(elem.total_seconds())
+                _hours, _remainder = divmod(_total_seconds, 3600)
+                _minutes, _seconds = divmod(_remainder, 60)
+                row_to_persist += (f"{_hours:02}:{_minutes:02}:{_seconds:02}",) # this should convert time column into 'HH:MM:SS' formatted string
             else:
                 epoch = datetime.datetime.utcfromtimestamp(0)
                 timedelta_from_epoch = epoch + elem

--- a/tests/unit/sync_strategies/test_common.py
+++ b/tests/unit/sync_strategies/test_common.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta, timezone
+
+from singer.catalog import CatalogEntry
+from singer.schema import Schema
+
+from tap_mysql.sync_strategies.common import row_to_singer_record
+
+
+def test_row_to_singer_record():
+    catalog_entry = CatalogEntry(
+        stream='stream',
+        schema=Schema.from_dict({
+            'type': 'object',
+            'properties': {
+                'time': {
+                    'type': 'string',
+                    'format': 'time',
+                },
+            },
+        }),
+    )
+    message = row_to_singer_record(
+        catalog_entry,
+        version=1,
+        row=(timedelta(hours=8, minutes=30),),
+        columns=['time'],
+        time_extracted=datetime.now(timezone.utc),
+    )
+
+    assert message.stream == 'stream'
+    assert message.version == 1
+    assert message.record == {'time': '08:30:00'}
+    assert message.time_extracted is not None


### PR DESCRIPTION
## Context

Values like `8:30:00` fail validation against a `{"type": "string", "format": "time"}` schema, because they're not compliant with the specification.

## Problem

Values of `time` fields are coming through as `8:30:00`, for example. This is because the code incorrectly assumes the `timedelta` object will be stringified to `HH:MM:SS`:

https://github.com/transferwise/pipelinewise-tap-mysql/blob/b86a4c11394535d277368583b52010cedff24dd3/tap_mysql/sync_strategies/common.py#L104-L106

One quick example, shows this is not the case

```python
>>> import datetime
>>> str(datetime.timedelta(hours=8, minutes=30))
'8:30:00'
```

## Proposed changes

We need to make fields with `"format": "time"` consistent with [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). So changing the code to

```python
_total_seconds = int(elem.total_seconds())
_hours, _remainder = divmod(_total_seconds, 3600)
_minutes, _seconds = divmod(_remainder, 60)
row_to_persist += (f"{_hours:02}:{_minutes:02}:{_seconds:02}",) # this should convert time column into 'HH:MM:SS' formatted string
```

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions